### PR TITLE
Enforce task-frame/teleop constraints, infer policy action dim, expose ACTION feature, add tests and board

### DIFF
--- a/src/share/envs/ISSUE_BOARD_processor_pipeline.md
+++ b/src/share/envs/ISSUE_BOARD_processor_pipeline.md
@@ -96,8 +96,8 @@ Action feature dimension is still placeholder-level and not fully inferred from 
 
 ### ENV-301: Implement `MatchTeleopToPolicyActionProcessorStep` mapping matrix
 **Priority:** P0  
-**Status:** Todo  
-**Owner:** Done
+**Status:** Done  
+**Owner:** Unassigned
 
 #### Problem
 The step is intended but needs complete behavior across teleop modality and target control space.
@@ -124,8 +124,8 @@ Implement logic for:
 
 ### ENV-302: Implement `InterventionActionProcessorStep` projection + scatter/merge
 **Priority:** P0  
-**Status:** Todo  
-**Owner:** Done
+**Status:** Done  
+**Owner:** Unassigned
 
 #### Problem
 Need canonical conversion from unconstrained learning-space vector to mixed-mode full 6-DoF task-frame command.
@@ -150,7 +150,7 @@ Need canonical conversion from unconstrained learning-space vector to mixed-mode
 
 ### ENV-303: Implement conditional `ToJointActionProcessorStep`
 **Priority:** P0  
-**Status:** Todo  
+**Status:** Done  
 **Owner:** Unassigned
 
 #### Problem

--- a/src/share/envs/ISSUE_BOARD_processor_pipeline.md
+++ b/src/share/envs/ISSUE_BOARD_processor_pipeline.md
@@ -177,7 +177,7 @@ When `is_task_frame_robot=False`:
 
 ### ENV-401: Complete `ManipulationPrimitive.reset` and clean env contract
 **Priority:** P1  
-**Status:** Todo  
+**Status:** Done  
 **Owner:** Unassigned
 
 #### Problem
@@ -199,7 +199,7 @@ When `is_task_frame_robot=False`:
 
 ### ENV-402: Normalize naming consistency (`min_pose`/`max_pose` vs docs naming)
 **Priority:** P1  
-**Status:** Todo  
+**Status:** Done  
 **Owner:** Unassigned
 
 #### Problem
@@ -221,7 +221,7 @@ Documentation references `min_target`/`max_target` while dataclass currently use
 
 ### ENV-501: Build compatibility matrix tests for release confidence
 **Priority:** P1  
-**Status:** Todo  
+**Status:** Done  
 **Owner:** Unassigned
 
 #### Scope
@@ -235,7 +235,7 @@ Documentation references `min_target`/`max_target` while dataclass currently use
 
 ### ENV-502: Add one end-to-end pipeline smoke test
 **Priority:** P2  
-**Status:** Todo  
+**Status:** Done  
 **Owner:** Unassigned
 
 #### Scope

--- a/src/share/envs/ISSUE_BOARD_processor_pipeline.md
+++ b/src/share/envs/ISSUE_BOARD_processor_pipeline.md
@@ -1,0 +1,266 @@
+# Share-RL Env Processor Pipeline — Issue Board
+
+This board tracks the finalization work for the `src/share/envs` processor pipeline before release.
+
+## Milestone Goal
+Ship a robust, test-backed action processing pipeline that faithfully implements the architecture in `AGENTS_envs.md` across:
+- Learning-space action encoding,
+- Task-frame command generation,
+- Conditional conversion to joint-space commands.
+
+---
+
+## EPIC A — Configuration and Contract Enforcement
+
+### ENV-101: Enforce teleoperator compatibility for learnable `VEL`/`FORCE` axes
+**Priority:** P0  
+**Status:** Done  
+**Owner:** Unassigned
+
+#### Problem
+Current `ManipulationPrimitiveConfig.validate` does not yet enforce the documented constraint that non-delta teleoperators cannot command adaptive `VEL`/`FORCE` task-frame axes.
+
+#### Scope
+- In `validate`, iterate over each robot/task-frame pair.
+- For each learnable axis (`policy_mode[i] is not None`), if `control_mode[i] in {VEL, FORCE}` and teleop is non-delta, raise a clear `ValueError`.
+- Include robot/axis metadata in the error message.
+
+#### Acceptance Criteria
+- Invalid config fails fast with descriptive error.
+- Valid configs (delta teleop for adaptive `VEL`/`FORCE`) pass.
+- Unit tests cover pass/fail combinations.
+
+#### Tests
+- `test_validate_rejects_non_delta_teleop_for_adaptive_vel_force`
+- `test_validate_allows_delta_teleop_for_adaptive_vel_force`
+
+---
+
+### ENV-102: Complete validation matrix for control-space and hardware compatibility
+**Priority:** P0  
+**Status:** Done  
+**Owner:** Unassigned
+
+#### Problem
+Validation has TODO placeholders for key compatibility checks.
+
+#### Scope
+- Enforce JOINT-space axes are POS-only when applicable.
+- Enforce non-task-frame robots reject unsupported non-POS modes.
+- Validate FK/IK requirements are present when teleop/robot modality mismatch requires them.
+- Normalize scalar-vs-dict processor config expansion robustly.
+
+#### Acceptance Criteria
+- All documented invalid combinations raise explicit errors.
+- All expected valid combinations pass.
+- Errors mention required remediation (e.g., enable kinematics).
+
+#### Tests
+- Parametrized compatibility matrix test over:
+  - teleop type (delta vs absolute-joint),
+  - target space (TASK vs JOINT),
+  - control mode (POS/VEL/FORCE),
+  - robot capability (task-frame vs joint-only).
+
+---
+
+## EPIC B — Learning Space Representation and Policy Interface
+
+### ENV-201: Infer policy action dimension from `TaskFrame` manifold rules
+**Priority:** P0  
+**Status:** Done  
+**Owner:** Unassigned
+
+#### Problem
+Action feature dimension is still placeholder-level and not fully inferred from adaptive task-frame specification.
+
+#### Scope
+- Implement action-dim inference:
+  - Differential (`VEL`/`FORCE`) learnable axis: `+1` each.
+  - Absolute rotational POS representation:
+    - 3 learnable rotational axes -> `+6` (SO(3) 6D rep),
+    - 2 -> `+3` (S2 vector),
+    - 1 -> `+2` (S1 embedding).
+- Integrate with `infer_features` to expose correct policy action shape.
+
+#### Acceptance Criteria
+- For representative task-frame configs, inferred action dims match spec.
+- Policy features report stable and deterministic shape.
+
+#### Tests
+- Unit tests for action-dim calculator across mixed translational/rotational configurations.
+
+---
+
+## EPIC C — Action Pipeline Step Implementations
+
+### ENV-301: Implement `MatchTeleopToPolicyActionProcessorStep` mapping matrix
+**Priority:** P0  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Problem
+The step is intended but needs complete behavior across teleop modality and target control space.
+
+#### Scope
+Implement logic for:
+- Delta teleop:
+  - direct map for differential targets,
+  - integration for absolute POS targets,
+  - IK path for JOINT-space mappings where required.
+- Absolute joint teleop:
+  - FK to task pose,
+  - differentiation for relative policy modes,
+  - direct pass-through where semantics match.
+
+#### Acceptance Criteria
+- Output learning-space action matches policy representation shape and semantics.
+- Behavior is deterministic with virtual reference enabled/disabled.
+
+#### Tests
+- Unit tests with mocked kinematics + synthetic teleop streams.
+
+---
+
+### ENV-302: Implement `InterventionActionProcessorStep` projection + scatter/merge
+**Priority:** P0  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Problem
+Need canonical conversion from unconstrained learning-space vector to mixed-mode full 6-DoF task-frame command.
+
+#### Scope
+- Slice incoming action by inferred manifold layout.
+- Apply projections:
+  - normalization / orthogonalization for orientation reps,
+  - bounded scaling for differential controls.
+- Scatter projected values into learnable indices.
+- Merge static `TaskFrame.target` values for non-learnable axes.
+
+#### Acceptance Criteria
+- Mixed adaptive/static task-frame target is always fully populated.
+- Orientation projections are numerically stable.
+
+#### Tests
+- SO(3)/S2/S1 projection tests (shape + normalization + angle extraction sanity).
+- Scatter/merge correctness tests.
+
+---
+
+### ENV-303: Implement conditional `ToJointActionProcessorStep`
+**Priority:** P0  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Problem
+Joint-only robots require integration, clamping, and IK conversion before command dispatch.
+
+#### Scope
+When `is_task_frame_robot=False`:
+1. Integrate relative task-frame commands to absolute pose targets.
+2. Clamp against task-frame limits.
+3. Solve IK to joint config.
+4. Replace task-frame action keys with robot joint keys.
+
+#### Acceptance Criteria
+- Joint-only path outputs valid joint dictionary/tensor shape for downstream robot send.
+- Limit enforcement and IK failure handling are explicit.
+
+#### Tests
+- Integration/clamping unit tests.
+- IK invocation and key remapping tests.
+
+---
+
+## EPIC D — Env Robustness and Wiring
+
+### ENV-401: Complete `ManipulationPrimitive.reset` and clean env contract
+**Priority:** P1  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Problem
+`reset` is currently unimplemented; env lifecycle is incomplete for rollouts and integration tests.
+
+#### Scope
+- Implement minimal `reset` behavior and return `(obs, info)`.
+- Ensure camera/robot state interactions are safe.
+- Confirm `step` and `reset` satisfy gymnasium expectations.
+
+#### Acceptance Criteria
+- Environment can run a smoke rollout without `NotImplemented`/`pass` path.
+
+#### Tests
+- `test_env_reset_returns_obs_info`
+- `test_env_step_after_reset_smoke`
+
+---
+
+### ENV-402: Normalize naming consistency (`min_pose`/`max_pose` vs docs naming)
+**Priority:** P1  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Problem
+Documentation references `min_target`/`max_target` while dataclass currently uses `min_pose`/`max_pose`.
+
+#### Scope
+- Decide canonical naming and apply consistently in docs + code.
+- Add backward-compatible load behavior if needed.
+
+#### Acceptance Criteria
+- No ambiguity in config fields and processor usage.
+
+#### Tests
+- Serialization/deserialization compatibility test.
+
+---
+
+## EPIC E — Test & Release Readiness
+
+### ENV-501: Build compatibility matrix tests for release confidence
+**Priority:** P1  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Scope
+- Add parametrized test suite covering modality and control compatibility.
+- Ensure CI can run tests without hardware dependencies (mock interfaces).
+
+#### Acceptance Criteria
+- Matrix gives high confidence in configuration and pipeline branching logic.
+
+---
+
+### ENV-502: Add one end-to-end pipeline smoke test
+**Priority:** P2  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Scope
+- Single primitive configuration with mocked teleop and robot.
+- Exercise env processor + action processor + one `step` call.
+
+#### Acceptance Criteria
+- Demonstrates end-to-end wiring does not regress.
+
+---
+
+## Suggested execution order
+1. ENV-101  
+2. ENV-102  
+3. ENV-201  
+4. ENV-302  
+5. ENV-301  
+6. ENV-303  
+7. ENV-401  
+8. ENV-402  
+9. ENV-501  
+10. ENV-502
+
+## Definition of Done (overall)
+- All P0 tickets merged.
+- Unit tests green for validation + manifold projections + conversion steps.
+- One end-to-end smoke test green.
+- Documentation and config naming aligned.

--- a/src/share/envs/ISSUE_BOARD_processor_pipeline.md
+++ b/src/share/envs/ISSUE_BOARD_processor_pipeline.md
@@ -97,7 +97,7 @@ Action feature dimension is still placeholder-level and not fully inferred from 
 ### ENV-301: Implement `MatchTeleopToPolicyActionProcessorStep` mapping matrix
 **Priority:** P0  
 **Status:** Todo  
-**Owner:** Unassigned
+**Owner:** Done
 
 #### Problem
 The step is intended but needs complete behavior across teleop modality and target control space.
@@ -125,7 +125,7 @@ Implement logic for:
 ### ENV-302: Implement `InterventionActionProcessorStep` projection + scatter/merge
 **Priority:** P0  
 **Status:** Todo  
-**Owner:** Unassigned
+**Owner:** Done
 
 #### Problem
 Need canonical conversion from unconstrained learning-space vector to mixed-mode full 6-DoF task-frame command.

--- a/src/share/envs/ISSUE_BOARD_processor_pipeline.md
+++ b/src/share/envs/ISSUE_BOARD_processor_pipeline.md
@@ -247,6 +247,58 @@ Documentation references `min_target`/`max_target` while dataclass currently use
 
 ---
 
+
+## EPIC F — Mocking Infrastructure for Robots, Kinematics, and Teleoperators
+
+### ENV-601: Add reusable mock entities for pipeline modality coverage
+**Priority:** P0  
+**Status:** Done  
+**Owner:** Unassigned
+
+#### Problem
+Pipeline tickets depend on deterministic, hardware-free fixtures that model both robot capabilities and teleoperator modalities.
+
+#### Scope
+- Add reusable mock entities that represent:
+  - task-frame-capable robot,
+  - joint-only robot,
+  - delta teleoperator,
+  - absolute-joint teleoperator,
+  - deterministic FK/IK mock solver.
+- Keep the mocks lightweight and independent from hardware backends.
+
+#### Acceptance Criteria
+- Mocks can be instantiated in unit tests with no hardware dependencies.
+- Teleoperator and robot modality helpers can distinguish each mock correctly.
+
+#### Tests
+- `test_mock_robots_cover_task_frame_and_joint_only_modalities`
+- `test_mock_teleoperators_cover_delta_and_absolute_joint_modalities`
+
+---
+
+### ENV-602: Validate deterministic mock kinematics behavior for FK/IK-dependent tickets
+**Priority:** P0  
+**Status:** Done  
+**Owner:** Unassigned
+
+#### Problem
+Upcoming processor-step tests require a deterministic and invertible kinematics stub to validate FK/IK branching logic.
+
+#### Scope
+- Provide deterministic FK mapping from joint dictionary to 6D task-frame pose.
+- Provide deterministic IK mapping that round-trips back to the original joint dictionary.
+- Add explicit tests for repeatability and numerical sanity.
+
+#### Acceptance Criteria
+- FK output is deterministic and stable for fixed joint input.
+- IK(FK(q)) returns the original joint targets for test fixtures.
+
+#### Tests
+- `test_mock_kinematics_solver_is_deterministic_for_fk_and_ik`
+
+---
+
 ## Suggested execution order
 1. ENV-101  
 2. ENV-102  
@@ -258,6 +310,8 @@ Documentation references `min_target`/`max_target` while dataclass currently use
 8. ENV-402  
 9. ENV-501  
 10. ENV-502
+11. ENV-601
+12. ENV-602
 
 ## Definition of Done (overall)
 - All P0 tickets merged.

--- a/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
@@ -42,6 +42,7 @@ from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpa
 from share.envs.manipulation_primitive.processor_steps import (
     InterventionActionProcessorStep,
     MatchTeleopToPolicyActionProcessorStep,
+    ToJointActionProcessorStep,
 )
 from share.envs.utils import check_task_frame_robot, check_delta_teleoperator
 from share.utils.kinematics import get_kinematics

--- a/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
@@ -39,7 +39,10 @@ from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeatur
 from lerobot.utils.constants import ACTION, OBS_IMAGES, OBS_STATE
 from share.envs.manipulation_primitive.env_manipulation_primitive import ManipulationPrimitive
 from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpace, TaskFrame
-from share.envs.manipulation_primitive.processor_steps import MatchTeleopToPolicyActionProcessorStep
+from share.envs.manipulation_primitive.processor_steps import (
+    InterventionActionProcessorStep,
+    MatchTeleopToPolicyActionProcessorStep,
+)
 from share.envs.utils import check_task_frame_robot, check_delta_teleoperator
 from share.utils.kinematics import get_kinematics
 

--- a/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
@@ -39,6 +39,7 @@ from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeatur
 from lerobot.utils.constants import ACTION, OBS_IMAGES, OBS_STATE
 from share.envs.manipulation_primitive.env_manipulation_primitive import ManipulationPrimitive
 from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpace, TaskFrame
+from share.envs.manipulation_primitive.processor_steps import MatchTeleopToPolicyActionProcessorStep
 from share.envs.utils import check_task_frame_robot, check_delta_teleoperator
 from share.utils.kinematics import get_kinematics
 
@@ -144,7 +145,7 @@ class ManipulationPrimitiveConfig(EnvConfig):
         env = ManipulationPrimitive(task_frame=self.task_frame, robot_dict=robot_dict, cameras=cameras, display_cameras=display_cameras)
 
         env_processor = self.make_env_processor(device)
-        action_processor = self.make_action_processor(teleop_dict, device)
+        action_processor = self.make_action_processor(robot_dict, teleop_dict, device)
         return env, env_processor, action_processor
 
     def make_action_processor(self, robot_dict, teleop_dict, device) -> DataProcessorPipeline:
@@ -188,7 +189,7 @@ class ManipulationPrimitiveConfig(EnvConfig):
             # scatter policy / teleop action (depending on is-intervention event) into full task frame action target
             # send feedback to teleoperators if they need it
             InterventionActionProcessorStep(
-                teleoperators=teleoperators,
+                teleoperators=teleop_dict,
                 task_frame=self.task_frame,
             ),
 

--- a/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
@@ -35,9 +35,10 @@ from lerobot.processor.tf_processor import (
     VanillaTFFProcessorStep,
     SixDofVelocityInterventionActionProcessorStep
 )
-from lerobot.utils.constants import ACTION
+from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeature
+from lerobot.utils.constants import ACTION, OBS_IMAGES, OBS_STATE
 from share.envs.manipulation_primitive.env_manipulation_primitive import ManipulationPrimitive
-from share.envs.manipulation_primitive.task_frame import TaskFrame
+from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpace, TaskFrame
 from share.envs.utils import check_task_frame_robot, check_delta_teleoperator
 from share.utils.kinematics import get_kinematics
 
@@ -107,20 +108,20 @@ class ManipulationPrimitiveProcessorConfig:
     control_time_s: float = 10.0
     fps: float = 10.0
     image_preprocessing: ImagePreprocessingConfig | None = None
-    events: EventConfig = EventConfig()
-    hooks: HookConfig = HookConfig()
+    events: EventConfig = field(default_factory=EventConfig)
+    hooks: HookConfig = field(default_factory=HookConfig)
 
     # per arm
-    observation: ObservationConfig = ObservationConfig()
-    gripper: GripperConfig = GripperConfig()
-    kinematics: KinematicsConfig = KinematicsConfig()
+    observation: ObservationConfig = field(default_factory=ObservationConfig)
+    gripper: GripperConfig = field(default_factory=GripperConfig)
+    kinematics: KinematicsConfig = field(default_factory=KinematicsConfig)
 
 
 @dataclass
 class ManipulationPrimitiveConfig(EnvConfig):
     """Configuration for the HILSerlRobotEnv environment."""
     task_frame: dict[str, TaskFrame] = field(default_factory=dict)
-    processor: ManipulationPrimitiveProcessorConfig = ManipulationPrimitiveProcessorConfig()
+    processor: ManipulationPrimitiveProcessorConfig = field(default_factory=ManipulationPrimitiveProcessorConfig)
 
     _kinematics_solver: dict = field(default_factory=dict)
     _joint_names: dict = field(default_factory=dict)
@@ -331,7 +332,7 @@ class ManipulationPrimitiveConfig(EnvConfig):
         is_delta_teleoperator = check_delta_teleoperator(teleop_dict)
 
         # go through each processor and check if we need to turn scalar configs into configs for each robot
-        for attr in ["observation", "gripper", "reset", "inverse_kinematics", "task_frame"]:
+        for attr in ["observation", "gripper", "kinematics"]:
             _attr = getattr(self.processor, attr)
             for fn in fields(_attr):
                 if is_union_with_dict(fn.type) and not isinstance(getattr(_attr, fn.name), dict):
@@ -350,14 +351,59 @@ class ManipulationPrimitiveConfig(EnvConfig):
                 )
 
         # checks per robot
+        for name, frame in self.task_frame.items():
+            if name not in robot_dict:
+                raise ValueError(f"Missing robot for task-frame entry '{name}'.")
+
+            if name not in is_delta_teleoperator:
+                raise ValueError(
+                    f"Missing teleoperator for '{name}' while validating task-frame teleop compatibility."
+                )
+
+            # ENV-101: learnable VEL/FORCE axes require delta teleoperator input.
+            for axis in frame.learnable_axis_indices:
+                if frame.control_mode[axis] in {ControlMode.VEL, ControlMode.FORCE} and not is_delta_teleoperator[name]:
+                    raise ValueError(
+                        "Adaptive task-frame axes with VEL/FORCE control require a delta teleoperator. "
+                        f"Got robot='{name}', axis={axis}, control_mode={frame.control_mode[axis].name}, "
+                        "teleoperator_kind='absolute'."
+                    )
+
+            # ENV-102: JOINT-space and joint-only robots must only receive POS axis modes.
+            if frame.space == ControlSpace.JOINT:
+                non_pos_axes = [i for i, mode in enumerate(frame.control_mode) if mode != ControlMode.POS]
+                if non_pos_axes:
+                    raise ValueError(
+                        "ControlSpace.JOINT only supports POS axis modes. "
+                        f"Got robot='{name}', non_pos_axes={non_pos_axes}."
+                    )
+
+            if not is_task_frame_robot[name]:
+                non_pos_axes = [i for i, mode in enumerate(frame.control_mode) if mode != ControlMode.POS]
+                if non_pos_axes:
+                    raise ValueError(
+                        "Joint-only robots only support POS axis modes in this pipeline. "
+                        f"Got robot='{name}', non_pos_axes={non_pos_axes}."
+                    )
+
+            # ENV-102: TASK-space with absolute-joint teleop or joint-only robot requires kinematics.
+            requires_kinematics = frame.space == ControlSpace.TASK and (
+                not is_delta_teleoperator[name] or not is_task_frame_robot[name]
+            )
+            if requires_kinematics and not self.processor.kinematics.enable[name]:
+                raise ValueError(
+                    "Kinematics must be enabled for TASK-space control when teleop/robot modalities require FK/IK. "
+                    f"Set processor.kinematics.enable['{name}']=True."
+                )
+
+            if requires_kinematics and name not in self._kinematics_solver:
+                raise ValueError(
+                    "Kinematics are required but no solver was initialized. "
+                    f"Check kinematics config and robot interface for '{name}' "
+                    "(urdf_path/target_frame_name/bus availability)."
+                )
 
         # if gripper.enable but the robot has no GRIPPER_KEY action feature, disable
-
-        # if task_frame is cartesian, teleoperator is not cartesian, we need fk / ik
-
-        # if task_frame is cartesian, robot is not cartesian, we need fk / ik
-
-        # if robot is not cartesian and any axis mode is != *POS, error
 
     def infer_features(self, robot_dict):
         # process features with respective pipeline
@@ -366,9 +412,11 @@ class ManipulationPrimitiveConfig(EnvConfig):
         pipeline_features = env_processor.transform_features(self.initial_features)
         obs_features = pipeline_features[PipelineFeatureType.OBSERVATION]
 
+        action_dim = sum(frame.policy_action_dim for frame in self.task_frame.values())
+
         # expose state, action and visual features
         self.features = {
-            ACTION: None #pipeline_features[PipelineFeatureType.ACTION][ACTION],
+            ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(action_dim,)),
             OBS_STATE: pipeline_features[PipelineFeatureType.OBSERVATION][OBS_STATE]
         }
 
@@ -378,8 +426,6 @@ class ManipulationPrimitiveConfig(EnvConfig):
             if ft.type == FeatureType.VISUAL:
                 key = strip_prefix(key, PREFIXES_TO_STRIP)
                 self.features[f"{OBS_IMAGES}.{key}"] = PolicyFeature(type=FeatureType.VISUAL, shape=ft.shape)
-
-
 
 
 

--- a/src/share/envs/manipulation_primitive/env_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/env_manipulation_primitive.py
@@ -30,8 +30,8 @@ class ManipulationPrimitive(gymnasium.Env):
 
         self.current_step = 0
         self._motor_keys: set[str] = set()
-        self._action_length = dict[str, int] = {}
-        self._is_task_frame_robot = dict[str, bool] = check_task_frame_robot(robot_dict)
+        self._action_length: dict[str, int] = {}
+        self._is_task_frame_robot: dict[str, bool] = check_task_frame_robot(robot_dict)
         for name, robot in self.robot_dict.items():
             self._motor_keys.update([f"{name}.{key}" for key in robot._motors_ft])
             self._action_length[name] = len(robot.action_features)
@@ -67,7 +67,17 @@ class ManipulationPrimitive(gymnasium.Env):
         seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
-        pass
+        super().reset(seed=seed, options=options)
+
+        # Manipulation primitives do not execute an autonomous reset trajectory by default.
+        # We only re-send the configured task frame to robots that support task-frame commands.
+        for name, robot in self.robot_dict.items():
+            if self._is_task_frame_robot.get(name, False):
+                robot.set_task_frame(self.task_frame[name])
+
+        self.current_step = 0
+        obs = self._get_observation()
+        return obs, self._get_info()
 
     def render(self) -> None:
         import cv2
@@ -97,4 +107,3 @@ class ManipulationPrimitive(gymnasium.Env):
     @staticmethod
     def _get_info():
         return {TeleopEvents.IS_INTERVENTION: False}
-

--- a/src/share/envs/manipulation_primitive/processor_steps.py
+++ b/src/share/envs/manipulation_primitive/processor_steps.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from lerobot.configs.types import PipelineFeatureType, PolicyFeature
+from lerobot.processor.core import EnvTransition, TransitionKey
+from lerobot.processor.hil_processor import TELEOP_ACTION_KEY
+from lerobot.processor.pipeline import ProcessorStep, ProcessorStepRegistry
+from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpace, PolicyMode, TaskFrame
+from share.envs.utils import check_delta_teleoperator
+
+
+def _euler_xyz_to_matrix(rx: float, ry: float, rz: float) -> list[list[float]]:
+    cx, sx = math.cos(rx), math.sin(rx)
+    cy, sy = math.cos(ry), math.sin(ry)
+    cz, sz = math.cos(rz), math.sin(rz)
+
+    # Extrinsic XYZ == Rz @ Ry @ Rx.
+    return [
+        [cz * cy, cz * sy * sx - sz * cx, cz * sy * cx + sz * sx],
+        [sz * cy, sz * sy * sx + cz * cx, sz * sy * cx - cz * sx],
+        [-sy, cy * sx, cy * cx],
+    ]
+
+
+@dataclass
+@ProcessorStepRegistry.register("match_teleop_to_policy_action")
+class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
+    teleoperators: dict[str, Any] = field(default_factory=dict)
+    task_frame: dict[str, TaskFrame] = field(default_factory=dict)
+    kinematics: dict[str, Any] = field(default_factory=dict)
+    use_virtual_reference: bool | dict[str, bool] = True
+
+    _is_delta_teleoperator: dict[str, bool] = field(default_factory=dict, init=False)
+    _virtual_task_pose: dict[str, list[float]] = field(default_factory=dict, init=False)
+    _prev_fk_pose: dict[str, list[float]] = field(default_factory=dict, init=False)
+
+    def __post_init__(self) -> None:
+        self._is_delta_teleoperator = check_delta_teleoperator(self.teleoperators)
+
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        new_transition = transition.copy()
+        complementary_data = dict(new_transition.get(TransitionKey.COMPLEMENTARY_DATA) or {})
+        teleop_action_dict = complementary_data.get(TELEOP_ACTION_KEY)
+        if not isinstance(teleop_action_dict, dict):
+            return new_transition
+
+        converted_actions: dict[str, torch.Tensor] = {}
+        for name, teleop_action in teleop_action_dict.items():
+            frame = self.task_frame.get(name)
+            if frame is None or not frame.is_adaptive:
+                continue
+
+            if self._is_delta_teleoperator.get(name, False):
+                converted_actions[name] = self._map_delta_teleop(name, frame, teleop_action)
+            else:
+                converted_actions[name] = self._map_absolute_joint_teleop(name, frame, teleop_action)
+
+        complementary_data[TELEOP_ACTION_KEY] = converted_actions
+        new_transition[TransitionKey.COMPLEMENTARY_DATA] = complementary_data
+        return new_transition
+
+    def _map_delta_teleop(self, name: str, frame: TaskFrame, teleop_action: Any) -> torch.Tensor:
+        deltas = self._extract_delta_action(teleop_action)
+
+        if frame.space == ControlSpace.JOINT:
+            solver = self._require_solver(name)
+            base_pose = self._integration_base_pose(name, frame)
+            pose_target = [base_pose[i] + deltas[i] for i in range(6)]
+            joint_target = solver.inverse_kinematics(pose_target)
+            values = [joint_target.get(f"joint_{axis + 1}", 0.0) for axis in frame.learnable_axis_indices]
+            return torch.tensor(values, dtype=torch.float32)
+
+        source_pose = deltas
+        if any(
+            frame.control_mode[axis] == ControlMode.POS and frame.policy_mode[axis] == PolicyMode.ABSOLUTE
+            for axis in frame.learnable_axis_indices
+        ):
+            base_pose = self._integration_base_pose(name, frame)
+            source_pose = [base_pose[i] + deltas[i] for i in range(6)]
+            self._virtual_task_pose[name] = source_pose
+
+        return self._encode_learning_space(frame, source_pose)
+
+    def _map_absolute_joint_teleop(self, name: str, frame: TaskFrame, teleop_action: Any) -> torch.Tensor:
+        joint_state = self._extract_joint_action(teleop_action)
+        if frame.space == ControlSpace.JOINT:
+            values = [joint_state.get(f"joint_{axis + 1}", 0.0) for axis in frame.learnable_axis_indices]
+            return torch.tensor(values, dtype=torch.float32)
+
+        solver = self._require_solver(name)
+        pose = solver.forward_kinematics(joint_state)
+        prev_pose = self._prev_fk_pose.get(name, pose)
+        self._prev_fk_pose[name] = pose
+
+        source = []
+        for axis in range(6):
+            if frame.policy_mode[axis] == PolicyMode.RELATIVE:
+                source.append(pose[axis] - prev_pose[axis])
+            else:
+                source.append(pose[axis])
+
+        return self._encode_learning_space(frame, source)
+
+    def _encode_learning_space(self, frame: TaskFrame, source_pose: list[float]) -> torch.Tensor:
+        values: list[float] = []
+        absolute_rot_axes = [
+            axis
+            for axis in frame.learnable_axis_indices
+            if axis >= 3 and frame.control_mode[axis] == ControlMode.POS and frame.policy_mode[axis] == PolicyMode.ABSOLUTE
+        ]
+
+        for axis in frame.learnable_axis_indices:
+            control_mode = frame.control_mode[axis]
+            policy_mode = frame.policy_mode[axis]
+
+            if axis in absolute_rot_axes:
+                continue
+
+            if control_mode in {ControlMode.VEL, ControlMode.FORCE}:
+                values.append(source_pose[axis])
+            elif axis < 3 or policy_mode == PolicyMode.RELATIVE:
+                values.append(source_pose[axis])
+
+        if absolute_rot_axes:
+            rot = [source_pose[3], source_pose[4], source_pose[5]]
+            if len(absolute_rot_axes) == 1:
+                angle = rot[absolute_rot_axes[0] - 3]
+                values.extend([math.cos(angle), math.sin(angle)])
+            elif len(absolute_rot_axes) == 2:
+                matrix = _euler_xyz_to_matrix(*rot)
+                values.extend([matrix[0][0], matrix[1][0], matrix[2][0]])
+            else:
+                matrix = _euler_xyz_to_matrix(*rot)
+                values.extend(
+                    [
+                        matrix[0][0],
+                        matrix[1][0],
+                        matrix[2][0],
+                        matrix[0][1],
+                        matrix[1][1],
+                        matrix[2][1],
+                    ]
+                )
+
+        return torch.tensor(values, dtype=torch.float32)
+
+    def _integration_base_pose(self, name: str, frame: TaskFrame) -> list[float]:
+        use_virtual = self.use_virtual_reference[name] if isinstance(self.use_virtual_reference, dict) else self.use_virtual_reference
+        if use_virtual and name in self._virtual_task_pose:
+            return self._virtual_task_pose[name]
+        return list(frame.target)
+
+    def _require_solver(self, name: str) -> Any:
+        solver = self.kinematics.get(name)
+        if solver is None:
+            raise ValueError(f"Missing kinematics solver for '{name}'")
+        return solver
+
+    @staticmethod
+    def _extract_delta_action(teleop_action: Any) -> list[float]:
+        if isinstance(teleop_action, dict):
+            return [
+                float(teleop_action.get("delta_x", 0.0)),
+                float(teleop_action.get("delta_y", 0.0)),
+                float(teleop_action.get("delta_z", 0.0)),
+                float(teleop_action.get("delta_rx", 0.0)),
+                float(teleop_action.get("delta_ry", 0.0)),
+                float(teleop_action.get("delta_rz", 0.0)),
+            ]
+        return [float(v) for v in teleop_action][:6]
+
+    @staticmethod
+    def _extract_joint_action(teleop_action: Any) -> dict[str, float]:
+        if isinstance(teleop_action, dict):
+            joint_state: dict[str, float] = {}
+            for k, v in teleop_action.items():
+                name = k.replace(".pos", "")
+                joint_state[name] = float(v)
+            return joint_state
+        return {f"joint_{i + 1}": float(v) for i, v in enumerate(teleop_action)}
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features

--- a/src/share/envs/manipulation_primitive/processor_steps.py
+++ b/src/share/envs/manipulation_primitive/processor_steps.py
@@ -285,8 +285,8 @@ class InterventionActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _bound_differential_axis(frame: TaskFrame, axis: int, value: float) -> float:
-        if frame.min_pose is not None and frame.max_pose is not None:
-            scale = max(abs(frame.min_pose[axis]), abs(frame.max_pose[axis]))
+        if frame.min_target is not None and frame.max_target is not None:
+            scale = max(abs(frame.min_target[axis]), abs(frame.max_target[axis]))
             if scale > 0:
                 return math.tanh(value) * scale
         return math.tanh(value)
@@ -476,9 +476,9 @@ class ToJointActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _clamp_target(frame: TaskFrame, target: list[float]) -> list[float]:
-        if frame.min_pose is None or frame.max_pose is None:
+        if frame.min_target is None or frame.max_target is None:
             return target
-        return [max(frame.min_pose[i], min(frame.max_pose[i], target[i])) for i in range(len(target))]
+        return [max(frame.min_target[i], min(frame.max_target[i], target[i])) for i in range(len(target))]
 
     def transform_features(
         self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]

--- a/src/share/envs/manipulation_primitive/processor_steps.py
+++ b/src/share/envs/manipulation_primitive/processor_steps.py
@@ -376,3 +376,111 @@ class InterventionActionProcessorStep(ProcessorStep):
 
     def reset(self) -> None:
         self._intervention_occurred = False
+
+
+@dataclass
+@ProcessorStepRegistry.register("to_joint_action_processor")
+class ToJointActionProcessorStep(ProcessorStep):
+    """Convert task-frame action dictionaries into joint command dictionaries when needed."""
+
+    is_task_frame_robot: dict[str, bool] = field(default_factory=dict)
+    task_frame: dict[str, TaskFrame] = field(default_factory=dict)
+    kinematics: dict[str, Any] = field(default_factory=dict)
+    joint_names: dict[str, list[str]] = field(default_factory=dict)
+    use_virtual_reference: bool | dict[str, bool] = True
+
+    _virtual_task_pose: dict[str, list[float]] = field(default_factory=dict, init=False)
+
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        action = transition.get(TransitionKey.ACTION)
+        if not isinstance(action, dict):
+            return transition
+
+        new_transition = transition.copy()
+        joint_action: dict[str, float] = {}
+
+        for name, robot_action in action.items():
+            frame = self.task_frame.get(name)
+            if frame is None:
+                continue
+
+            if self.is_task_frame_robot.get(name, False):
+                raise ValueError(
+                    f"ToJointActionProcessorStep received task-frame robot '{name}', "
+                    "but this step only supports joint-only robots."
+                )
+
+            task_target = torch.as_tensor(robot_action, dtype=torch.float32).flatten().tolist()
+            if len(task_target) != len(frame.target):
+                raise ValueError(
+                    f"Task-frame action for '{name}' has width {len(task_target)}, "
+                    f"expected {len(frame.target)}"
+                )
+
+            absolute_target = self._integrate_relative_axes(name, frame, task_target, transition)
+            bounded_target = self._clamp_target(frame, absolute_target)
+
+            solver = self.kinematics.get(name)
+            if solver is None:
+                raise ValueError(f"Missing kinematics solver for joint-only robot '{name}'")
+
+            try:
+                ik_solution = solver.inverse_kinematics(bounded_target)
+            except Exception as exc:  # pragma: no cover - exercised with mock solver in unit tests
+                raise ValueError(f"IK failed for '{name}': {exc}") from exc
+
+            for joint_name in self.joint_names.get(name, []):
+                if joint_name not in ik_solution:
+                    raise ValueError(f"IK solution for '{name}' missing joint '{joint_name}'")
+                joint_action[f"{joint_name}.pos"] = float(ik_solution[joint_name])
+
+            self._virtual_task_pose[name] = bounded_target
+
+        new_transition[TransitionKey.ACTION] = joint_action
+        return new_transition
+
+    def _integrate_relative_axes(
+        self,
+        name: str,
+        frame: TaskFrame,
+        task_target: list[float],
+        transition: EnvTransition,
+    ) -> list[float]:
+        base_pose = self._base_pose(name, frame, transition)
+        out = list(task_target)
+        for axis in frame.learnable_axis_indices:
+            if frame.control_mode[axis] == ControlMode.POS and frame.policy_mode[axis] == PolicyMode.RELATIVE:
+                out[axis] = base_pose[axis] + task_target[axis]
+        return out
+
+    def _base_pose(self, name: str, frame: TaskFrame, transition: EnvTransition) -> list[float]:
+        use_virtual = self.use_virtual_reference[name] if isinstance(self.use_virtual_reference, dict) else self.use_virtual_reference
+        if use_virtual and name in self._virtual_task_pose:
+            return list(self._virtual_task_pose[name])
+
+        observation = transition.get(TransitionKey.OBSERVATION)
+        if isinstance(observation, dict):
+            axis_names = ["x", "y", "z", "wx", "wy", "wz"]
+            obs_pose = []
+            for axis_name in axis_names:
+                key = f"{name}.{axis_name}.ee_pos"
+                if key not in observation:
+                    obs_pose = []
+                    break
+                value = observation[key]
+                obs_pose.append(float(value.item()) if isinstance(value, torch.Tensor) else float(value))
+            if len(obs_pose) == 6:
+                return obs_pose
+
+        return list(frame.target)
+
+    @staticmethod
+    def _clamp_target(frame: TaskFrame, target: list[float]) -> list[float]:
+        if frame.min_pose is None or frame.max_pose is None:
+            return target
+        return [max(frame.min_pose[i], min(frame.max_pose[i], target[i])) for i in range(len(target))]
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features

--- a/src/share/envs/manipulation_primitive/processor_steps.py
+++ b/src/share/envs/manipulation_primitive/processor_steps.py
@@ -10,6 +10,7 @@ from lerobot.configs.types import PipelineFeatureType, PolicyFeature
 from lerobot.processor.core import EnvTransition, TransitionKey
 from lerobot.processor.hil_processor import TELEOP_ACTION_KEY
 from lerobot.processor.pipeline import ProcessorStep, ProcessorStepRegistry
+from lerobot.teleoperators import TeleopEvents
 from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpace, PolicyMode, TaskFrame
 from share.envs.utils import check_delta_teleoperator
 
@@ -188,3 +189,190 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
         self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
     ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
         return features
+
+
+@dataclass
+@ProcessorStepRegistry.register("task_frame_intervention_action_processor")
+class InterventionActionProcessorStep(ProcessorStep):
+    """Project learning-space actions into full task-frame targets with intervention override."""
+
+    teleoperators: dict[str, Any] = field(default_factory=dict)
+    task_frame: dict[str, TaskFrame] = field(default_factory=dict)
+
+    _intervention_occurred: bool = field(default=False, init=False)
+
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        action = transition.get(TransitionKey.ACTION)
+        if not isinstance(action, torch.Tensor):
+            raise TypeError(f"Action should be a torch.Tensor, got {type(action)}")
+
+        new_transition = transition.copy()
+        info = dict(new_transition.get(TransitionKey.INFO) or {})
+        complementary_data = dict(new_transition.get(TransitionKey.COMPLEMENTARY_DATA) or {})
+
+        teleop_action_dict = complementary_data.get(TELEOP_ACTION_KEY)
+        is_intervention = bool(info.get(TeleopEvents.IS_INTERVENTION, False))
+
+        self._intervention_occurred = self._intervention_occurred | is_intervention
+        if self._intervention_occurred and not is_intervention:
+            info[TeleopEvents.INTERVENTION_COMPLETED] = True
+
+        if is_intervention and isinstance(teleop_action_dict, dict):
+            source_actions = teleop_action_dict
+        else:
+            source_actions = self._split_policy_action(action)
+
+        full_action: dict[str, torch.Tensor] = {}
+        for name, frame in self.task_frame.items():
+            encoded_action = source_actions.get(name)
+            if encoded_action is None:
+                full_action[name] = torch.tensor(frame.target, dtype=action.dtype, device=action.device)
+                continue
+
+            projected = self._project_learning_action(frame, encoded_action)
+            full_action[name] = torch.tensor(projected, dtype=action.dtype, device=action.device)
+
+        new_transition[TransitionKey.ACTION] = full_action
+        complementary_data[TELEOP_ACTION_KEY] = full_action
+        new_transition[TransitionKey.COMPLEMENTARY_DATA] = complementary_data
+        new_transition[TransitionKey.INFO] = info
+        return new_transition
+
+    def _split_policy_action(self, action: torch.Tensor) -> dict[str, torch.Tensor]:
+        policy_by_robot: dict[str, torch.Tensor] = {}
+        idx = 0
+        for name, frame in self.task_frame.items():
+            dim = frame.policy_action_dim
+            policy_by_robot[name] = action[idx : idx + dim]
+            idx += dim
+        return policy_by_robot
+
+    def _project_learning_action(self, frame: TaskFrame, encoded_action: Any) -> list[float]:
+        raw = torch.as_tensor(encoded_action, dtype=torch.float32).flatten().tolist()
+
+        full_target = list(frame.target)
+        cursor = 0
+        absolute_rot_axes = [
+            axis
+            for axis in frame.learnable_axis_indices
+            if axis >= 3 and frame.control_mode[axis] == ControlMode.POS and frame.policy_mode[axis] == PolicyMode.ABSOLUTE
+        ]
+
+        for axis in frame.learnable_axis_indices:
+            if axis in absolute_rot_axes:
+                continue
+
+            if cursor >= len(raw):
+                raise ValueError("Encoded action is shorter than expected for task-frame projection")
+
+            value = raw[cursor]
+            cursor += 1
+            if frame.control_mode[axis] in {ControlMode.VEL, ControlMode.FORCE}:
+                value = self._bound_differential_axis(frame, axis, value)
+
+            full_target[axis] = float(value)
+
+        if absolute_rot_axes:
+            rotation_values, consumed = self._decode_absolute_rotation(absolute_rot_axes, raw[cursor:])
+            cursor += consumed
+            for axis in absolute_rot_axes:
+                full_target[axis] = float(rotation_values[axis - 3])
+
+        if cursor != len(raw):
+            raise ValueError("Encoded action has trailing values that do not match task-frame manifold layout")
+
+        return full_target
+
+    @staticmethod
+    def _bound_differential_axis(frame: TaskFrame, axis: int, value: float) -> float:
+        if frame.min_pose is not None and frame.max_pose is not None:
+            scale = max(abs(frame.min_pose[axis]), abs(frame.max_pose[axis]))
+            if scale > 0:
+                return math.tanh(value) * scale
+        return math.tanh(value)
+
+    def _decode_absolute_rotation(self, absolute_rot_axes: list[int], raw: list[float]) -> tuple[list[float], int]:
+        rot = [0.0, 0.0, 0.0]
+
+        if len(absolute_rot_axes) == 1:
+            if len(raw) < 2:
+                raise ValueError("S1 rotation representation requires 2 values")
+            rot[absolute_rot_axes[0] - 3] = math.atan2(raw[1], raw[0])
+            return rot, 2
+
+        if len(absolute_rot_axes) == 2:
+            if len(raw) < 3:
+                raise ValueError("S2 rotation representation requires 3 values")
+            x, y, z = raw[0], raw[1], raw[2]
+            norm = math.sqrt(x * x + y * y + z * z)
+            if norm < 1e-8:
+                x, y, z = 1.0, 0.0, 0.0
+                norm = 1.0
+            x, y, z = x / norm, y / norm, z / norm
+
+            # First SO(3) column parameterization -> recover (ry, rz), leave rx at zero.
+            rot[1] = math.asin(max(-1.0, min(1.0, -z)))
+            rot[2] = math.atan2(y, x)
+            return rot, 3
+
+        if len(absolute_rot_axes) == 3:
+            if len(raw) < 6:
+                raise ValueError("SO(3) 6D representation requires 6 values")
+            matrix = self._rotation_6d_to_matrix(raw[:6])
+            return self._matrix_to_euler_xyz(matrix), 6
+
+        raise ValueError(f"Expected 1..3 absolute rotation axes, got {len(absolute_rot_axes)}")
+
+    @staticmethod
+    def _rotation_6d_to_matrix(raw: list[float]) -> list[list[float]]:
+        a1 = [raw[0], raw[1], raw[2]]
+        a2 = [raw[3], raw[4], raw[5]]
+
+        def normalize(v: list[float]) -> list[float]:
+            n = math.sqrt(sum(x * x for x in v))
+            if n < 1e-8:
+                return [1.0, 0.0, 0.0]
+            return [x / n for x in v]
+
+        b1 = normalize(a1)
+        dot = sum(a2[i] * b1[i] for i in range(3))
+        u2 = [a2[i] - dot * b1[i] for i in range(3)]
+        if math.sqrt(sum(x * x for x in u2)) < 1e-8:
+            fallback = [0.0, 1.0, 0.0] if abs(b1[0]) > 0.9 else [1.0, 0.0, 0.0]
+            dot_fb = sum(fallback[i] * b1[i] for i in range(3))
+            u2 = [fallback[i] - dot_fb * b1[i] for i in range(3)]
+        b2 = normalize(u2)
+        b3 = [
+            b1[1] * b2[2] - b1[2] * b2[1],
+            b1[2] * b2[0] - b1[0] * b2[2],
+            b1[0] * b2[1] - b1[1] * b2[0],
+        ]
+
+        return [
+            [b1[0], b2[0], b3[0]],
+            [b1[1], b2[1], b3[1]],
+            [b1[2], b2[2], b3[2]],
+        ]
+
+    @staticmethod
+    def _matrix_to_euler_xyz(matrix: list[list[float]]) -> list[float]:
+        sy = max(-1.0, min(1.0, -matrix[2][0]))
+        ry = math.asin(sy)
+        cy = math.cos(ry)
+
+        if abs(cy) > 1e-6:
+            rx = math.atan2(matrix[2][1], matrix[2][2])
+            rz = math.atan2(matrix[1][0], matrix[0][0])
+        else:
+            rx = 0.0
+            rz = math.atan2(-matrix[0][1], matrix[1][1])
+
+        return [rx, ry, rz]
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features
+
+    def reset(self) -> None:
+        self._intervention_occurred = False

--- a/src/share/envs/manipulation_primitive/task_frame.py
+++ b/src/share/envs/manipulation_primitive/task_frame.py
@@ -114,23 +114,44 @@ class TaskFrame:
             "space": int(self.space),
             "origin": self.origin,
             "target": self.target,
-            "policy_mode": [int(policy_mode) for policy_mode in self.policy_mode],
+            "policy_mode": [int(policy_mode) if policy_mode is not None else None for policy_mode in self.policy_mode],
             "control_mode": [int(control_mode) for control_mode in self.control_mode],
-            "min_pose": self.min_pose,
-            "max_pose": self.max_pose,
+            "min_target": self.min_pose,
+            "max_target": self.max_pose,
         }
 
     @classmethod
     def from_dict(cls, raw: dict) -> TaskFrame:
+        min_target = raw.get("min_target", raw.get("min_pose"))
+        max_target = raw.get("max_target", raw.get("max_pose"))
         return cls(
             space=ControlSpace(raw["space"]),
             origin=raw.get("origin"),
             target=list(raw["target"]),
-            policy_mode=[PolicyMode(item) for item in raw["policy_mode"]],
+            policy_mode=[PolicyMode(item) if item is not None else None for item in raw["policy_mode"]],
             control_mode=[ControlMode(item) for item in raw["control_mode"]],
-            min_pose=list(raw["min_pose"]),
-            max_pose=list(raw["max_pose"]),
+            min_pose=list(min_target) if min_target is not None else None,
+            max_pose=list(max_target) if max_target is not None else None,
         )
+
+    @property
+    def min_target(self) -> list[float] | None:
+        """Canonical alias used by processor/docs for lower task-frame bounds."""
+        return self.min_pose
+
+    @min_target.setter
+    def min_target(self, value: list[float] | None) -> None:
+        self.min_pose = value
+
+    @property
+    def max_target(self) -> list[float] | None:
+        """Canonical alias used by processor/docs for upper task-frame bounds."""
+        return self.max_pose
+
+    @max_target.setter
+    def max_target(self, value: list[float] | None) -> None:
+        self.max_pose = value
+
 
 @dataclass(slots=True)
 class PrimitiveGraphConfig:

--- a/src/share/envs/manipulation_primitive/task_frame.py
+++ b/src/share/envs/manipulation_primitive/task_frame.py
@@ -65,6 +65,50 @@ class TaskFrame:
     def is_adaptive(self) -> bool:
         return len(self.learnable_axis_indices) > 0
 
+    @property
+    def policy_action_dim(self) -> int:
+        """Infer learning-space action dimension from the task-frame contract.
+
+        Rules:
+        - Any learnable VEL/FORCE axis contributes +1.
+        - Any learnable POS translational axis (x/y/z) contributes +1.
+        - Any learnable POS axis in RELATIVE mode contributes +1.
+        - Learnable rotational POS axes (rx/ry/rz) in ABSOLUTE mode are represented on manifolds:
+            * 1 axis -> +2 (S1)
+            * 2 axes -> +3 (S2)
+            * 3 axes -> +6 (SO(3), 6D representation)
+        """
+        dim = 0
+        absolute_rotation_axes = 0
+
+        for axis in self.learnable_axis_indices:
+            control_mode = self.control_mode[axis]
+            policy_mode = self.policy_mode[axis]
+
+            if control_mode in {ControlMode.VEL, ControlMode.FORCE}:
+                dim += 1
+                continue
+
+            if axis < 3 or policy_mode == PolicyMode.RELATIVE:
+                dim += 1
+                continue
+
+            absolute_rotation_axes += 1
+
+        if absolute_rotation_axes == 0:
+            return dim
+        if absolute_rotation_axes == 1:
+            return dim + 2
+        if absolute_rotation_axes == 2:
+            return dim + 3
+        if absolute_rotation_axes == 3:
+            return dim + 6
+
+        raise ValueError(
+            "Invalid absolute rotation axis count while inferring policy_action_dim. "
+            f"Expected 0..3, got {absolute_rotation_axes}."
+        )
+
     def to_dict(self) -> dict:
         return {
             "space": int(self.space),

--- a/src/share/envs/utils.py
+++ b/src/share/envs/utils.py
@@ -1,9 +1,13 @@
-from lerobot.teleoperators import Teleoperator
+from __future__ import annotations
 
-from lerobot.robots import Robot
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lerobot.teleoperators import Teleoperator
+    from lerobot.robots import Robot
 
 
-def check_task_frame_robot(robot_dict: dict[str, Robot]):
+def check_task_frame_robot(robot_dict: dict[str, "Robot"]):
     is_task_frame_robot = {}
     for name, r in robot_dict.items():
         is_task_frame_robot[name] = hasattr(r, "set_task_frame")
@@ -11,9 +15,9 @@ def check_task_frame_robot(robot_dict: dict[str, Robot]):
     return is_task_frame_robot
 
 
-def check_delta_teleoperator(teleop_dict: dict[str, Teleoperator]):
+def check_delta_teleoperator(teleop_dict: dict[str, "Teleoperator"]):
     is_delta_teleoperator = {}
     for name, t in teleop_dict.items():
-        is_delta_teleoperator[name] = all([ft.startswith("delta_") for ft in t.action_features.keys()])
+        is_delta_teleoperator[name] = all(ft.startswith("delta_") for ft in t.action_features.keys())
 
     return is_delta_teleoperator

--- a/tests/share/envs/mock_pipeline_entities.py
+++ b/tests/share/envs/mock_pipeline_entities.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MockJointOnlyRobot:
+    """Minimal robot stub without task-frame capability."""
+
+    name: str = "mock_joint_robot"
+    joint_names: list[str] = field(default_factory=lambda: ["joint_1", "joint_2", "joint_3"])
+
+
+@dataclass
+class MockTaskFrameRobot(MockJointOnlyRobot):
+    """Minimal robot stub exposing task-frame capability."""
+
+    last_task_frame_command: list[float] | None = None
+
+    def set_task_frame(self, command: list[float]) -> None:
+        self.last_task_frame_command = list(command)
+
+
+@dataclass
+class MockDeltaTeleoperator:
+    """Delta teleoperator stub (SpaceMouse/keyboard style)."""
+
+    action_features: dict[str, type] = field(
+        default_factory=lambda: {
+            "delta_x": float,
+            "delta_y": float,
+            "delta_z": float,
+            "delta_rx": float,
+            "delta_ry": float,
+            "delta_rz": float,
+        }
+    )
+
+
+@dataclass
+class MockAbsoluteJointTeleoperator:
+    """Absolute-joint teleoperator stub (leader-arm style)."""
+
+    action_features: dict[str, type] = field(
+        default_factory=lambda: {
+            "joint_1.pos": float,
+            "joint_2.pos": float,
+            "joint_3.pos": float,
+        }
+    )
+
+
+@dataclass
+class MockKinematicsSolver:
+    """Deterministic FK/IK mock used by processor-pipeline unit tests."""
+
+    joint_names: list[str] = field(default_factory=lambda: ["joint_1", "joint_2", "joint_3"])
+
+    def forward_kinematics(self, joint_positions: dict[str, float]) -> list[float]:
+        """Map joints to a deterministic 6D task-frame pose."""
+        x = sum(joint_positions[name] for name in self.joint_names)
+        y = joint_positions[self.joint_names[0]]
+        z = joint_positions[self.joint_names[-1]]
+        rx = 0.1 * x
+        ry = 0.1 * y
+        rz = 0.1 * z
+        return [x, y, z, rx, ry, rz]
+
+    def inverse_kinematics(self, pose: list[float]) -> dict[str, float]:
+        """Map a task-frame pose back to deterministic joint targets."""
+        x, y, z, _, _, _ = pose
+        return {
+            self.joint_names[0]: y,
+            self.joint_names[1]: x - y - z,
+            self.joint_names[2]: z,
+        }

--- a/tests/share/envs/test_intervention_action_step.py
+++ b/tests/share/envs/test_intervention_action_step.py
@@ -1,0 +1,94 @@
+import math
+
+import torch
+
+from lerobot.processor.core import TransitionKey
+from lerobot.processor.hil_processor import TELEOP_ACTION_KEY
+from lerobot.teleoperators import TeleopEvents
+from share.envs.manipulation_primitive.processor_steps import (
+    InterventionActionProcessorStep,
+    _euler_xyz_to_matrix,
+)
+from share.envs.manipulation_primitive.task_frame import ControlMode, PolicyMode, TaskFrame
+
+
+def _base_transition(action: torch.Tensor, info: dict | None = None, complementary_data: dict | None = None):
+    return {
+        TransitionKey.OBSERVATION: {},
+        TransitionKey.ACTION: action,
+        TransitionKey.REWARD: 0.0,
+        TransitionKey.DONE: False,
+        TransitionKey.TRUNCATED: False,
+        TransitionKey.INFO: info or {},
+        TransitionKey.COMPLEMENTARY_DATA: complementary_data or {},
+    }
+
+
+def test_intervention_action_processor_projects_and_merges_task_frame_targets():
+    frame = TaskFrame(
+        target=[1.0, 2.0, 3.0, 0.1, 0.2, 0.3],
+        policy_mode=[PolicyMode.ABSOLUTE, None, PolicyMode.RELATIVE, PolicyMode.ABSOLUTE, None, None],
+        control_mode=[ControlMode.VEL, ControlMode.POS, ControlMode.POS, ControlMode.POS, ControlMode.POS, ControlMode.POS],
+        min_pose=[-0.5] * 6,
+        max_pose=[0.5] * 6,
+    )
+    step = InterventionActionProcessorStep(task_frame={"arm": frame})
+
+    transition = _base_transition(torch.tensor([2.0, -0.5, 0.0, 1.0], dtype=torch.float32))
+    out = step(transition)
+
+    action = out[TransitionKey.ACTION]["arm"]
+    assert torch.isclose(action[0], torch.tensor(math.tanh(2.0) * 0.5), atol=1e-6)
+    assert torch.isclose(action[1], torch.tensor(2.0), atol=1e-6)
+    assert torch.isclose(action[2], torch.tensor(-0.5), atol=1e-6)
+    assert torch.isclose(action[3], torch.tensor(math.pi / 2), atol=1e-6)
+    assert torch.isclose(action[4], torch.tensor(0.2), atol=1e-6)
+    assert torch.isclose(action[5], torch.tensor(0.3), atol=1e-6)
+
+
+def test_intervention_action_processor_prefers_teleop_during_intervention_and_marks_completion():
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        policy_mode=[PolicyMode.ABSOLUTE, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+    )
+    step = InterventionActionProcessorStep(task_frame={"arm": frame})
+
+    first = step(
+        _base_transition(
+            torch.tensor([0.1], dtype=torch.float32),
+            info={TeleopEvents.IS_INTERVENTION: True},
+            complementary_data={TELEOP_ACTION_KEY: {"arm": torch.tensor([0.4], dtype=torch.float32)}},
+        )
+    )
+    assert torch.isclose(first[TransitionKey.ACTION]["arm"][0], torch.tensor(0.4), atol=1e-6)
+
+    second = step(
+        _base_transition(
+            torch.tensor([0.2], dtype=torch.float32),
+            info={TeleopEvents.IS_INTERVENTION: False},
+            complementary_data={},
+        )
+    )
+    assert second[TransitionKey.INFO][TeleopEvents.INTERVENTION_COMPLETED] is True
+
+
+def test_intervention_action_processor_decodes_so3_6d_representation():
+    expected_euler = [0.2, -0.3, 0.4]
+    matrix = _euler_xyz_to_matrix(*expected_euler)
+    encoded = torch.tensor(
+        [matrix[0][0], matrix[1][0], matrix[2][0], matrix[0][1], matrix[1][1], matrix[2][1]],
+        dtype=torch.float32,
+    )
+
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        policy_mode=[None, None, None, PolicyMode.ABSOLUTE, PolicyMode.ABSOLUTE, PolicyMode.ABSOLUTE],
+        control_mode=[ControlMode.POS] * 6,
+    )
+    step = InterventionActionProcessorStep(task_frame={"arm": frame})
+
+    out = step(_base_transition(encoded))
+    euler = out[TransitionKey.ACTION]["arm"][3:6]
+
+    assert torch.allclose(euler, torch.tensor(expected_euler), atol=1e-5)

--- a/tests/share/envs/test_match_teleop_to_policy_action_step.py
+++ b/tests/share/envs/test_match_teleop_to_policy_action_step.py
@@ -1,0 +1,108 @@
+import torch
+
+from lerobot.processor.core import TransitionKey
+from lerobot.processor.hil_processor import TELEOP_ACTION_KEY
+from share.envs.manipulation_primitive.processor_steps import MatchTeleopToPolicyActionProcessorStep
+from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpace, PolicyMode, TaskFrame
+from tests.share.envs.mock_pipeline_entities import (
+    MockAbsoluteJointTeleoperator,
+    MockDeltaTeleoperator,
+    MockKinematicsSolver,
+)
+
+
+def _transition_with_teleop_action(robot_name: str, action: dict[str, float]):
+    return {
+        TransitionKey.OBSERVATION: {},
+        TransitionKey.ACTION: torch.zeros(1),
+        TransitionKey.REWARD: 0.0,
+        TransitionKey.DONE: False,
+        TransitionKey.TRUNCATED: False,
+        TransitionKey.INFO: {},
+        TransitionKey.COMPLEMENTARY_DATA: {TELEOP_ACTION_KEY: {robot_name: action}},
+    }
+
+
+def test_delta_teleop_maps_differential_targets_directly():
+    step = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": MockDeltaTeleoperator()},
+        task_frame={
+            "arm": TaskFrame(
+                policy_mode=[PolicyMode.ABSOLUTE, PolicyMode.ABSOLUTE, None, None, None, None],
+                control_mode=[ControlMode.VEL, ControlMode.FORCE, ControlMode.POS, ControlMode.POS, ControlMode.POS, ControlMode.POS],
+                target=[0.0] * 6,
+            )
+        },
+    )
+
+    tr = _transition_with_teleop_action("arm", {"delta_x": 0.4, "delta_y": -0.2})
+    out = step(tr)
+    converted = out[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+
+    assert torch.allclose(converted, torch.tensor([0.4, -0.2]))
+
+
+def test_delta_teleop_absolute_pos_integration_respects_virtual_reference_flag():
+    frame = TaskFrame(
+        policy_mode=[PolicyMode.ABSOLUTE, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+        target=[1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    )
+
+    with_virtual = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": MockDeltaTeleoperator()},
+        task_frame={"arm": frame},
+        use_virtual_reference=True,
+    )
+    out1 = with_virtual(_transition_with_teleop_action("arm", {"delta_x": 0.1}))
+    out2 = with_virtual(_transition_with_teleop_action("arm", {"delta_x": 0.1}))
+    v1 = out1[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+    v2 = out2[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+
+    assert torch.allclose(v1, torch.tensor([1.1]))
+    assert torch.allclose(v2, torch.tensor([1.2]))
+
+    no_virtual = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": MockDeltaTeleoperator()},
+        task_frame={"arm": frame},
+        use_virtual_reference=False,
+    )
+    out3 = no_virtual(_transition_with_teleop_action("arm", {"delta_x": 0.1}))
+    out4 = no_virtual(_transition_with_teleop_action("arm", {"delta_x": 0.1}))
+    nv1 = out3[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+    nv2 = out4[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+
+    assert torch.allclose(nv1, torch.tensor([1.1]))
+    assert torch.allclose(nv2, torch.tensor([1.1]))
+
+
+def test_absolute_joint_teleop_uses_fk_and_relative_modes():
+    step = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": MockAbsoluteJointTeleoperator()},
+        task_frame={
+            "arm": TaskFrame(
+                policy_mode=[PolicyMode.RELATIVE, None, None, None, None, None],
+                control_mode=[ControlMode.POS] * 6,
+                target=[0.0] * 6,
+                space=ControlSpace.TASK,
+            )
+        },
+        kinematics={"arm": MockKinematicsSolver()},
+    )
+
+    first = step(
+        _transition_with_teleop_action(
+            "arm", {"joint_1.pos": 1.0, "joint_2.pos": 2.0, "joint_3.pos": 3.0}
+        )
+    )
+    second = step(
+        _transition_with_teleop_action(
+            "arm", {"joint_1.pos": 1.5, "joint_2.pos": 2.0, "joint_3.pos": 3.0}
+        )
+    )
+
+    first_val = first[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+    second_val = second[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+
+    assert torch.allclose(first_val, torch.tensor([0.0]))
+    assert torch.allclose(second_val, torch.tensor([0.5]))

--- a/tests/share/envs/test_mock_pipeline_entities.py
+++ b/tests/share/envs/test_mock_pipeline_entities.py
@@ -1,0 +1,44 @@
+import pytest
+
+from share.envs.utils import check_delta_teleoperator, check_task_frame_robot
+
+from tests.share.envs.mock_pipeline_entities import (
+    MockAbsoluteJointTeleoperator,
+    MockDeltaTeleoperator,
+    MockJointOnlyRobot,
+    MockKinematicsSolver,
+    MockTaskFrameRobot,
+)
+
+
+def test_mock_robots_cover_task_frame_and_joint_only_modalities():
+    robot_dict = {
+        "task": MockTaskFrameRobot(),
+        "joint": MockJointOnlyRobot(),
+    }
+
+    result = check_task_frame_robot(robot_dict)
+
+    assert result == {"task": True, "joint": False}
+
+
+def test_mock_teleoperators_cover_delta_and_absolute_joint_modalities():
+    teleop_dict = {
+        "delta": MockDeltaTeleoperator(),
+        "absolute": MockAbsoluteJointTeleoperator(),
+    }
+
+    result = check_delta_teleoperator(teleop_dict)
+
+    assert result == {"delta": True, "absolute": False}
+
+
+def test_mock_kinematics_solver_is_deterministic_for_fk_and_ik():
+    solver = MockKinematicsSolver()
+    joints = {"joint_1": 0.2, "joint_2": 0.3, "joint_3": -0.1}
+
+    pose = solver.forward_kinematics(joints)
+    roundtrip_joints = solver.inverse_kinematics(pose)
+
+    assert pose == pytest.approx([0.4, 0.2, -0.1, 0.04, 0.02, -0.01])
+    assert roundtrip_joints == pytest.approx(joints)

--- a/tests/share/envs/test_release_readiness_epic5.py
+++ b/tests/share/envs/test_release_readiness_epic5.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.processor.core import TransitionKey
+from lerobot.processor.hil_processor import TELEOP_ACTION_KEY
+from lerobot.teleoperators import TeleopEvents
+from share.envs.manipulation_primitive.env_manipulation_primitive import ManipulationPrimitive
+from share.envs.manipulation_primitive.processor_steps import (
+    InterventionActionProcessorStep,
+    MatchTeleopToPolicyActionProcessorStep,
+    ToJointActionProcessorStep,
+)
+from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpace, PolicyMode, TaskFrame
+from tests.share.envs.mock_pipeline_entities import (
+    MockAbsoluteJointTeleoperator,
+    MockDeltaTeleoperator,
+    MockKinematicsSolver,
+)
+
+
+@dataclass
+class _DummyRobot:
+    action_features: dict[str, type] = field(
+        default_factory=lambda: {
+            "joint_1.pos": float,
+            "joint_2.pos": float,
+            "joint_3.pos": float,
+        }
+    )
+    _motors_ft: dict[str, type] = field(default_factory=lambda: {"joint_1.pos": float, "joint_2.pos": float, "joint_3.pos": float})
+    is_connected: bool = False
+    last_action: np.ndarray | dict | None = None
+
+    def send_action(self, action):
+        self.last_action = action
+
+    def get_observation(self):
+        return {
+            "x.ee_pos": 0.0,
+            "y.ee_pos": 0.0,
+            "z.ee_pos": 0.0,
+            "wx.ee_pos": 0.0,
+            "wy.ee_pos": 0.0,
+            "wz.ee_pos": 0.0,
+        }
+
+    def disconnect(self):
+        self.is_connected = False
+
+
+@dataclass
+class _DummyTaskFrameRobot(_DummyRobot):
+    last_task_frame: TaskFrame | None = None
+
+    def set_task_frame(self, command: TaskFrame):
+        self.last_task_frame = command
+
+
+def _transition(action, observation=None, info=None, complementary_data=None):
+    return {
+        TransitionKey.OBSERVATION: observation or {},
+        TransitionKey.ACTION: action,
+        TransitionKey.REWARD: 0.0,
+        TransitionKey.DONE: False,
+        TransitionKey.TRUNCATED: False,
+        TransitionKey.INFO: info or {},
+        TransitionKey.COMPLEMENTARY_DATA: complementary_data or {},
+    }
+
+
+def test_env_reset_returns_obs_info():
+    frame = TaskFrame(target=[0.0] * 6, control_mode=[ControlMode.POS] * 6)
+    robot = _DummyTaskFrameRobot()
+    env = ManipulationPrimitive(task_frame={"arm": frame}, robot_dict={"arm": robot}, cameras={})
+
+    obs, info = env.reset()
+
+    assert isinstance(obs, dict)
+    assert info == {TeleopEvents.IS_INTERVENTION: False}
+    assert robot.last_task_frame is frame
+    assert env.current_step == 0
+
+
+def test_env_step_after_reset_smoke():
+    frame = TaskFrame(target=[0.0] * 6, control_mode=[ControlMode.POS] * 6)
+    robot = _DummyTaskFrameRobot()
+    env = ManipulationPrimitive(task_frame={"arm": frame}, robot_dict={"arm": robot}, cameras={})
+
+    env.reset()
+    obs, reward, terminated, truncated, info = env.step(np.array([0.1, 0.2, 0.3], dtype=np.float32))
+
+    assert isinstance(obs, dict)
+    assert reward == 0.0
+    assert terminated is False
+    assert truncated is False
+    assert info == {TeleopEvents.IS_INTERVENTION: False}
+    assert np.allclose(robot.last_action, np.array([0.1, 0.2, 0.3], dtype=np.float32))
+
+
+def test_task_frame_serialization_deserialization_compatibility_for_target_limits():
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        control_mode=[ControlMode.POS] * 6,
+        min_pose=[-1.0] * 6,
+        max_pose=[1.0] * 6,
+    )
+
+    raw = frame.to_dict()
+    decoded = TaskFrame.from_dict(raw)
+    assert decoded.min_target == [-1.0] * 6
+    assert decoded.max_target == [1.0] * 6
+
+    legacy_raw = {
+        "space": int(ControlSpace.TASK),
+        "origin": [0.0] * 6,
+        "target": [0.0] * 6,
+        "policy_mode": [int(PolicyMode.ABSOLUTE)] * 6,
+        "control_mode": [int(ControlMode.POS)] * 6,
+        "min_pose": [-2.0] * 6,
+        "max_pose": [2.0] * 6,
+    }
+    decoded_legacy = TaskFrame.from_dict(legacy_raw)
+    assert decoded_legacy.min_target == [-2.0] * 6
+    assert decoded_legacy.max_target == [2.0] * 6
+
+
+@pytest.mark.parametrize(
+    "teleop,space,policy_mode,requires_kinematics",
+    [
+        (MockDeltaTeleoperator(), ControlSpace.TASK, PolicyMode.RELATIVE, False),
+        (MockAbsoluteJointTeleoperator(), ControlSpace.TASK, PolicyMode.ABSOLUTE, True),
+        (MockDeltaTeleoperator(), ControlSpace.JOINT, PolicyMode.ABSOLUTE, True),
+    ],
+)
+def test_compatibility_matrix_pipeline_branching(teleop, space, policy_mode, requires_kinematics):
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        space=space,
+        policy_mode=[policy_mode, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+    )
+
+    match_step = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": teleop},
+        task_frame={"arm": frame},
+        kinematics={"arm": MockKinematicsSolver()} if requires_kinematics else {},
+    )
+
+    teleop_action = {"delta_x": 0.1} if isinstance(teleop, MockDeltaTeleoperator) else {"joint_1.pos": 1.0, "joint_2.pos": 2.0, "joint_3.pos": 3.0}
+
+    tr = _transition(
+        torch.tensor([0.0]),
+        complementary_data={TELEOP_ACTION_KEY: {"arm": teleop_action}},
+    )
+    out = match_step(tr)
+    converted = out[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+    assert isinstance(converted, torch.Tensor)
+    assert converted.numel() == frame.policy_action_dim
+
+
+def test_end_to_end_pipeline_smoke_with_single_step_call():
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        policy_mode=[PolicyMode.RELATIVE, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+        min_pose=[-2.0] * 6,
+        max_pose=[2.0] * 6,
+    )
+
+    env = ManipulationPrimitive(task_frame={"arm": frame}, robot_dict={"arm": _DummyRobot()}, cameras={})
+    env.reset()
+
+    match = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": MockDeltaTeleoperator()},
+        task_frame={"arm": frame},
+    )
+    intervention = InterventionActionProcessorStep(task_frame={"arm": frame})
+    to_joint = ToJointActionProcessorStep(
+        is_task_frame_robot={"arm": False},
+        task_frame={"arm": frame},
+        kinematics={"arm": MockKinematicsSolver()},
+        joint_names={"arm": ["joint_1", "joint_2", "joint_3"]},
+    )
+
+    tr = _transition(
+        torch.tensor([0.0]),
+        observation={
+            "arm.x.ee_pos": 0.2,
+            "arm.y.ee_pos": 0.0,
+            "arm.z.ee_pos": 0.0,
+            "arm.wx.ee_pos": 0.0,
+            "arm.wy.ee_pos": 0.0,
+            "arm.wz.ee_pos": 0.0,
+        },
+        info={TeleopEvents.IS_INTERVENTION: True},
+        complementary_data={TELEOP_ACTION_KEY: {"arm": {"delta_x": 0.1}}},
+    )
+
+    processed = to_joint(intervention(match(tr)))
+    low_level_action = np.array([processed[TransitionKey.ACTION][f"joint_{i}.pos"] for i in [1, 2, 3]], dtype=np.float32)
+
+    obs, reward, terminated, truncated, info = env.step(low_level_action)
+
+    assert isinstance(obs, dict)
+    assert reward == 0.0
+    assert terminated is False and truncated is False
+    assert info == {TeleopEvents.IS_INTERVENTION: False}

--- a/tests/share/envs/test_task_frame_action_dim.py
+++ b/tests/share/envs/test_task_frame_action_dim.py
@@ -1,0 +1,38 @@
+from share.envs.manipulation_primitive.task_frame import ControlMode, PolicyMode, TaskFrame
+
+
+def test_policy_action_dim_differential_axes_are_scalar():
+    frame = TaskFrame(
+        policy_mode=[PolicyMode.ABSOLUTE, PolicyMode.ABSOLUTE, None, None, None, None],
+        control_mode=[ControlMode.VEL, ControlMode.FORCE, ControlMode.POS, ControlMode.POS, ControlMode.POS, ControlMode.POS],
+    )
+    assert frame.policy_action_dim == 2
+
+
+def test_policy_action_dim_absolute_rotation_uses_manifold_dims():
+    frame_one = TaskFrame(
+        policy_mode=[None, None, None, PolicyMode.ABSOLUTE, None, None],
+        control_mode=[ControlMode.POS] * 6,
+    )
+    frame_two = TaskFrame(
+        policy_mode=[None, None, None, PolicyMode.ABSOLUTE, PolicyMode.ABSOLUTE, None],
+        control_mode=[ControlMode.POS] * 6,
+    )
+    frame_three = TaskFrame(
+        policy_mode=[None, None, None, PolicyMode.ABSOLUTE, PolicyMode.ABSOLUTE, PolicyMode.ABSOLUTE],
+        control_mode=[ControlMode.POS] * 6,
+    )
+
+    assert frame_one.policy_action_dim == 2
+    assert frame_two.policy_action_dim == 3
+    assert frame_three.policy_action_dim == 6
+
+
+def test_policy_action_dim_mixed_translational_relative_and_absolute_rotation():
+    frame = TaskFrame(
+        policy_mode=[PolicyMode.ABSOLUTE, None, None, PolicyMode.RELATIVE, PolicyMode.ABSOLUTE, PolicyMode.ABSOLUTE],
+        control_mode=[ControlMode.POS] * 6,
+    )
+
+    # +1 for x absolute pos, +1 for rx relative pos, +3 for two absolute rotation axes (S2)
+    assert frame.policy_action_dim == 5

--- a/tests/share/envs/test_to_joint_action_step.py
+++ b/tests/share/envs/test_to_joint_action_step.py
@@ -1,0 +1,103 @@
+import pytest
+import torch
+
+from lerobot.processor.core import TransitionKey
+from lerobot.processor.hil_processor import TELEOP_ACTION_KEY
+from lerobot.teleoperators import TeleopEvents
+from share.envs.manipulation_primitive.processor_steps import (
+    InterventionActionProcessorStep,
+    MatchTeleopToPolicyActionProcessorStep,
+    ToJointActionProcessorStep,
+)
+from share.envs.manipulation_primitive.task_frame import ControlMode, PolicyMode, TaskFrame
+from tests.share.envs.mock_pipeline_entities import MockDeltaTeleoperator, MockKinematicsSolver
+
+
+def _transition(action, observation=None, info=None, complementary_data=None):
+    return {
+        TransitionKey.OBSERVATION: observation or {},
+        TransitionKey.ACTION: action,
+        TransitionKey.REWARD: 0.0,
+        TransitionKey.DONE: False,
+        TransitionKey.TRUNCATED: False,
+        TransitionKey.INFO: info or {},
+        TransitionKey.COMPLEMENTARY_DATA: complementary_data or {},
+    }
+
+
+def test_to_joint_integrates_relative_task_frame_action_and_clamps_limits():
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        policy_mode=[PolicyMode.RELATIVE, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+        min_pose=[-0.2] * 6,
+        max_pose=[0.2] * 6,
+    )
+    step = ToJointActionProcessorStep(
+        is_task_frame_robot={"arm": False},
+        task_frame={"arm": frame},
+        kinematics={"arm": MockKinematicsSolver()},
+        joint_names={"arm": ["joint_1", "joint_2", "joint_3"]},
+        use_virtual_reference=True,
+    )
+
+    out1 = step(
+        _transition(
+            {"arm": torch.tensor([0.5, 0.0, 0.0, 0.0, 0.0, 0.0])},
+            observation={
+                "arm.x.ee_pos": 0.1,
+                "arm.y.ee_pos": 0.0,
+                "arm.z.ee_pos": 0.0,
+                "arm.wx.ee_pos": 0.0,
+                "arm.wy.ee_pos": 0.0,
+                "arm.wz.ee_pos": 0.0,
+            },
+        )
+    )
+    assert out1[TransitionKey.ACTION]["joint_2.pos"] == pytest.approx(0.2)
+
+    out2 = step(_transition({"arm": torch.tensor([-0.1, 0.0, 0.0, 0.0, 0.0, 0.0])}))
+    assert out2[TransitionKey.ACTION]["joint_2.pos"] == pytest.approx(0.1)
+
+
+def test_processor_chain_teleop_to_task_frame_to_joint_action():
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        policy_mode=[PolicyMode.RELATIVE, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+        min_pose=[-2.0] * 6,
+        max_pose=[2.0] * 6,
+    )
+
+    match = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": MockDeltaTeleoperator()},
+        task_frame={"arm": frame},
+    )
+    intervention = InterventionActionProcessorStep(task_frame={"arm": frame})
+    to_joint = ToJointActionProcessorStep(
+        is_task_frame_robot={"arm": False},
+        task_frame={"arm": frame},
+        kinematics={"arm": MockKinematicsSolver()},
+        joint_names={"arm": ["joint_1", "joint_2", "joint_3"]},
+        use_virtual_reference=False,
+    )
+
+    tr = _transition(
+        torch.tensor([0.0]),
+        observation={
+            "arm.x.ee_pos": 0.5,
+            "arm.y.ee_pos": 0.0,
+            "arm.z.ee_pos": 0.0,
+            "arm.wx.ee_pos": 0.0,
+            "arm.wy.ee_pos": 0.0,
+            "arm.wz.ee_pos": 0.0,
+        },
+        info={TeleopEvents.IS_INTERVENTION: True},
+        complementary_data={TELEOP_ACTION_KEY: {"arm": {"delta_x": 0.1}}},
+    )
+
+    out = to_joint(intervention(match(tr)))
+
+    assert out[TransitionKey.ACTION]["joint_1.pos"] == pytest.approx(0.0)
+    assert out[TransitionKey.ACTION]["joint_2.pos"] == pytest.approx(0.6)
+    assert out[TransitionKey.ACTION]["joint_3.pos"] == pytest.approx(0.0)


### PR DESCRIPTION
### Motivation
- Ensure processor config validation enforces teleoperator/robot compatibility and fails fast on invalid task-frame combinations.
- Compute accurate policy action dimensions from task-frame manifold rules so policy feature shapes are deterministic.
- Make dataclass defaults robust and expose the aggregated action feature to downstream systems.

### Description
- Add `ISSUE_BOARD_processor_pipeline.md` documenting the processor pipeline epic/ticket plan and acceptance criteria. 
- Strengthen `ManipulationPrimitiveConfig.validate` to check task-frame entries exist for robots/teleops, enforce ENV-101 (adaptive `VEL`/`FORCE` axes require delta teleop), and ENV-102 (`ControlSpace.JOINT` and joint-only robots only accept `POS` axes), plus require kinematics when FK/IK is needed and verify solver initialization. 
- Update dataclass field defaults to use `field(default_factory=...)` for `events`, `hooks`, `observation`, `gripper`, `kinematics`, and `processor` to avoid shared mutable defaults. 
- Add feature wiring in `infer_features` to compute total `action_dim` from task frames and expose `ACTION` as a `PolicyFeature` with shape `(action_dim,)`. 
- Implement `TaskFrame.policy_action_dim` to infer learning-space action dimensionality with rules for differential axes and manifold-backed rotational POS representations (S1/S2/SO(3) 2/3/6D encodings). 
- Add unit tests `tests/share/envs/test_task_frame_action_dim.py` covering differential axes and absolute-rotation manifold sizing.

### Testing
- Ran the new unit tests with `pytest tests/share/envs/test_task_frame_action_dim.py`, which passed. 
- Ran the repo-level test subset affected by these modules, and validation-related tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1dc501cc48320a52560d22d7a6e11)