### PR TITLE
Add env pipeline mocking epic, reusable mocks, and tests

### DIFF
--- a/src/share/envs/ISSUE_BOARD_processor_pipeline.md
+++ b/src/share/envs/ISSUE_BOARD_processor_pipeline.md
@@ -247,6 +247,58 @@ Documentation references `min_target`/`max_target` while dataclass currently use
 
 ---
 
+
+## EPIC F — Mocking Infrastructure for Robots, Kinematics, and Teleoperators
+
+### ENV-601: Add reusable mock entities for pipeline modality coverage
+**Priority:** P0  
+**Status:** Done  
+**Owner:** Unassigned
+
+#### Problem
+Pipeline tickets depend on deterministic, hardware-free fixtures that model both robot capabilities and teleoperator modalities.
+
+#### Scope
+- Add reusable mock entities that represent:
+  - task-frame-capable robot,
+  - joint-only robot,
+  - delta teleoperator,
+  - absolute-joint teleoperator,
+  - deterministic FK/IK mock solver.
+- Keep the mocks lightweight and independent from hardware backends.
+
+#### Acceptance Criteria
+- Mocks can be instantiated in unit tests with no hardware dependencies.
+- Teleoperator and robot modality helpers can distinguish each mock correctly.
+
+#### Tests
+- `test_mock_robots_cover_task_frame_and_joint_only_modalities`
+- `test_mock_teleoperators_cover_delta_and_absolute_joint_modalities`
+
+---
+
+### ENV-602: Validate deterministic mock kinematics behavior for FK/IK-dependent tickets
+**Priority:** P0  
+**Status:** Done  
+**Owner:** Unassigned
+
+#### Problem
+Upcoming processor-step tests require a deterministic and invertible kinematics stub to validate FK/IK branching logic.
+
+#### Scope
+- Provide deterministic FK mapping from joint dictionary to 6D task-frame pose.
+- Provide deterministic IK mapping that round-trips back to the original joint dictionary.
+- Add explicit tests for repeatability and numerical sanity.
+
+#### Acceptance Criteria
+- FK output is deterministic and stable for fixed joint input.
+- IK(FK(q)) returns the original joint targets for test fixtures.
+
+#### Tests
+- `test_mock_kinematics_solver_is_deterministic_for_fk_and_ik`
+
+---
+
 ## Suggested execution order
 1. ENV-101  
 2. ENV-102  
@@ -258,6 +310,8 @@ Documentation references `min_target`/`max_target` while dataclass currently use
 8. ENV-402  
 9. ENV-501  
 10. ENV-502
+11. ENV-601
+12. ENV-602
 
 ## Definition of Done (overall)
 - All P0 tickets merged.

--- a/src/share/envs/utils.py
+++ b/src/share/envs/utils.py
@@ -1,9 +1,13 @@
-from lerobot.teleoperators import Teleoperator
+from __future__ import annotations
 
-from lerobot.robots import Robot
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lerobot.teleoperators import Teleoperator
+    from lerobot.robots import Robot
 
 
-def check_task_frame_robot(robot_dict: dict[str, Robot]):
+def check_task_frame_robot(robot_dict: dict[str, "Robot"]):
     is_task_frame_robot = {}
     for name, r in robot_dict.items():
         is_task_frame_robot[name] = hasattr(r, "set_task_frame")
@@ -11,9 +15,9 @@ def check_task_frame_robot(robot_dict: dict[str, Robot]):
     return is_task_frame_robot
 
 
-def check_delta_teleoperator(teleop_dict: dict[str, Teleoperator]):
+def check_delta_teleoperator(teleop_dict: dict[str, "Teleoperator"]):
     is_delta_teleoperator = {}
     for name, t in teleop_dict.items():
-        is_delta_teleoperator[name] = all([ft.startswith("delta_") for ft in t.action_features.keys()])
+        is_delta_teleoperator[name] = all(ft.startswith("delta_") for ft in t.action_features.keys())
 
     return is_delta_teleoperator

--- a/tests/share/envs/mock_pipeline_entities.py
+++ b/tests/share/envs/mock_pipeline_entities.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MockJointOnlyRobot:
+    """Minimal robot stub without task-frame capability."""
+
+    name: str = "mock_joint_robot"
+    joint_names: list[str] = field(default_factory=lambda: ["joint_1", "joint_2", "joint_3"])
+
+
+@dataclass
+class MockTaskFrameRobot(MockJointOnlyRobot):
+    """Minimal robot stub exposing task-frame capability."""
+
+    last_task_frame_command: list[float] | None = None
+
+    def set_task_frame(self, command: list[float]) -> None:
+        self.last_task_frame_command = list(command)
+
+
+@dataclass
+class MockDeltaTeleoperator:
+    """Delta teleoperator stub (SpaceMouse/keyboard style)."""
+
+    action_features: dict[str, type] = field(
+        default_factory=lambda: {
+            "delta_x": float,
+            "delta_y": float,
+            "delta_z": float,
+            "delta_rx": float,
+            "delta_ry": float,
+            "delta_rz": float,
+        }
+    )
+
+
+@dataclass
+class MockAbsoluteJointTeleoperator:
+    """Absolute-joint teleoperator stub (leader-arm style)."""
+
+    action_features: dict[str, type] = field(
+        default_factory=lambda: {
+            "joint_1.pos": float,
+            "joint_2.pos": float,
+            "joint_3.pos": float,
+        }
+    )
+
+
+@dataclass
+class MockKinematicsSolver:
+    """Deterministic FK/IK mock used by processor-pipeline unit tests."""
+
+    joint_names: list[str] = field(default_factory=lambda: ["joint_1", "joint_2", "joint_3"])
+
+    def forward_kinematics(self, joint_positions: dict[str, float]) -> list[float]:
+        """Map joints to a deterministic 6D task-frame pose."""
+        x = sum(joint_positions[name] for name in self.joint_names)
+        y = joint_positions[self.joint_names[0]]
+        z = joint_positions[self.joint_names[-1]]
+        rx = 0.1 * x
+        ry = 0.1 * y
+        rz = 0.1 * z
+        return [x, y, z, rx, ry, rz]
+
+    def inverse_kinematics(self, pose: list[float]) -> dict[str, float]:
+        """Map a task-frame pose back to deterministic joint targets."""
+        x, y, z, _, _, _ = pose
+        return {
+            self.joint_names[0]: y,
+            self.joint_names[1]: x - y - z,
+            self.joint_names[2]: z,
+        }

--- a/tests/share/envs/test_mock_pipeline_entities.py
+++ b/tests/share/envs/test_mock_pipeline_entities.py
@@ -1,0 +1,44 @@
+import pytest
+
+from share.envs.utils import check_delta_teleoperator, check_task_frame_robot
+
+from tests.share.envs.mock_pipeline_entities import (
+    MockAbsoluteJointTeleoperator,
+    MockDeltaTeleoperator,
+    MockJointOnlyRobot,
+    MockKinematicsSolver,
+    MockTaskFrameRobot,
+)
+
+
+def test_mock_robots_cover_task_frame_and_joint_only_modalities():
+    robot_dict = {
+        "task": MockTaskFrameRobot(),
+        "joint": MockJointOnlyRobot(),
+    }
+
+    result = check_task_frame_robot(robot_dict)
+
+    assert result == {"task": True, "joint": False}
+
+
+def test_mock_teleoperators_cover_delta_and_absolute_joint_modalities():
+    teleop_dict = {
+        "delta": MockDeltaTeleoperator(),
+        "absolute": MockAbsoluteJointTeleoperator(),
+    }
+
+    result = check_delta_teleoperator(teleop_dict)
+
+    assert result == {"delta": True, "absolute": False}
+
+
+def test_mock_kinematics_solver_is_deterministic_for_fk_and_ik():
+    solver = MockKinematicsSolver()
+    joints = {"joint_1": 0.2, "joint_2": 0.3, "joint_3": -0.1}
+
+    pose = solver.forward_kinematics(joints)
+    roundtrip_joints = solver.inverse_kinematics(pose)
+
+    assert pose == pytest.approx([0.4, 0.2, -0.1, 0.04, 0.02, -0.01])
+    assert roundtrip_joints == pytest.approx(joints)


### PR DESCRIPTION
### Motivation
- Provide deterministic, hardware-free fixtures so processor-pipeline tickets (FK/IK, teleop modality branching, etc.) can be implemented and tested without real robots.
- Prevent runtime import cycles in `share.envs` helpers so lightweight test fixtures can import `share.envs.utils` safely.

### Description
- Add EPIC F (ENV-601, ENV-602) to `src/share/envs/ISSUE_BOARD_processor_pipeline.md` documenting the new mocking infrastructure and tests.
- Implement reusable mock entities in `tests/share/envs/mock_pipeline_entities.py` including a task-frame-capable robot, a joint-only robot, delta and absolute-joint teleoperator stubs, and a deterministic FK/IK solver.
- Add focused unit tests in `tests/share/envs/test_mock_pipeline_entities.py` that validate robot/teleop modality detection and deterministic FK/IK round-trips.
- Harden `src/share/envs/utils.py` by moving `Robot`/`Teleoperator` imports under `TYPE_CHECKING`, enabling postponed/string annotations and avoiding circular imports at runtime.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/share/envs/test_mock_pipeline_entities.py tests/share/envs/test_task_frame_action_dim.py` and all tests passed (`6 passed`).
- The test run exercised the new mocks and the `TaskFrame.policy_action_dim` checks to ensure compatibility with existing unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e8fc2c748320b652b78c51393f29)