### PR TITLE
Implement ENV-303 ToJointActionProcessorStep and add chained processor tests

### DIFF
--- a/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
@@ -42,6 +42,7 @@ from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpa
 from share.envs.manipulation_primitive.processor_steps import (
     InterventionActionProcessorStep,
     MatchTeleopToPolicyActionProcessorStep,
+    ToJointActionProcessorStep,
 )
 from share.envs.utils import check_task_frame_robot, check_delta_teleoperator
 from share.utils.kinematics import get_kinematics

--- a/src/share/envs/manipulation_primitive/processor_steps.py
+++ b/src/share/envs/manipulation_primitive/processor_steps.py
@@ -376,3 +376,111 @@ class InterventionActionProcessorStep(ProcessorStep):
 
     def reset(self) -> None:
         self._intervention_occurred = False
+
+
+@dataclass
+@ProcessorStepRegistry.register("to_joint_action_processor")
+class ToJointActionProcessorStep(ProcessorStep):
+    """Convert task-frame action dictionaries into joint command dictionaries when needed."""
+
+    is_task_frame_robot: dict[str, bool] = field(default_factory=dict)
+    task_frame: dict[str, TaskFrame] = field(default_factory=dict)
+    kinematics: dict[str, Any] = field(default_factory=dict)
+    joint_names: dict[str, list[str]] = field(default_factory=dict)
+    use_virtual_reference: bool | dict[str, bool] = True
+
+    _virtual_task_pose: dict[str, list[float]] = field(default_factory=dict, init=False)
+
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        action = transition.get(TransitionKey.ACTION)
+        if not isinstance(action, dict):
+            return transition
+
+        new_transition = transition.copy()
+        joint_action: dict[str, float] = {}
+
+        for name, robot_action in action.items():
+            frame = self.task_frame.get(name)
+            if frame is None:
+                continue
+
+            if self.is_task_frame_robot.get(name, False):
+                raise ValueError(
+                    f"ToJointActionProcessorStep received task-frame robot '{name}', "
+                    "but this step only supports joint-only robots."
+                )
+
+            task_target = torch.as_tensor(robot_action, dtype=torch.float32).flatten().tolist()
+            if len(task_target) != len(frame.target):
+                raise ValueError(
+                    f"Task-frame action for '{name}' has width {len(task_target)}, "
+                    f"expected {len(frame.target)}"
+                )
+
+            absolute_target = self._integrate_relative_axes(name, frame, task_target, transition)
+            bounded_target = self._clamp_target(frame, absolute_target)
+
+            solver = self.kinematics.get(name)
+            if solver is None:
+                raise ValueError(f"Missing kinematics solver for joint-only robot '{name}'")
+
+            try:
+                ik_solution = solver.inverse_kinematics(bounded_target)
+            except Exception as exc:  # pragma: no cover - exercised with mock solver in unit tests
+                raise ValueError(f"IK failed for '{name}': {exc}") from exc
+
+            for joint_name in self.joint_names.get(name, []):
+                if joint_name not in ik_solution:
+                    raise ValueError(f"IK solution for '{name}' missing joint '{joint_name}'")
+                joint_action[f"{joint_name}.pos"] = float(ik_solution[joint_name])
+
+            self._virtual_task_pose[name] = bounded_target
+
+        new_transition[TransitionKey.ACTION] = joint_action
+        return new_transition
+
+    def _integrate_relative_axes(
+        self,
+        name: str,
+        frame: TaskFrame,
+        task_target: list[float],
+        transition: EnvTransition,
+    ) -> list[float]:
+        base_pose = self._base_pose(name, frame, transition)
+        out = list(task_target)
+        for axis in frame.learnable_axis_indices:
+            if frame.control_mode[axis] == ControlMode.POS and frame.policy_mode[axis] == PolicyMode.RELATIVE:
+                out[axis] = base_pose[axis] + task_target[axis]
+        return out
+
+    def _base_pose(self, name: str, frame: TaskFrame, transition: EnvTransition) -> list[float]:
+        use_virtual = self.use_virtual_reference[name] if isinstance(self.use_virtual_reference, dict) else self.use_virtual_reference
+        if use_virtual and name in self._virtual_task_pose:
+            return list(self._virtual_task_pose[name])
+
+        observation = transition.get(TransitionKey.OBSERVATION)
+        if isinstance(observation, dict):
+            axis_names = ["x", "y", "z", "wx", "wy", "wz"]
+            obs_pose = []
+            for axis_name in axis_names:
+                key = f"{name}.{axis_name}.ee_pos"
+                if key not in observation:
+                    obs_pose = []
+                    break
+                value = observation[key]
+                obs_pose.append(float(value.item()) if isinstance(value, torch.Tensor) else float(value))
+            if len(obs_pose) == 6:
+                return obs_pose
+
+        return list(frame.target)
+
+    @staticmethod
+    def _clamp_target(frame: TaskFrame, target: list[float]) -> list[float]:
+        if frame.min_pose is None or frame.max_pose is None:
+            return target
+        return [max(frame.min_pose[i], min(frame.max_pose[i], target[i])) for i in range(len(target))]
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features

--- a/tests/share/envs/test_to_joint_action_step.py
+++ b/tests/share/envs/test_to_joint_action_step.py
@@ -1,0 +1,103 @@
+import pytest
+import torch
+
+from lerobot.processor.core import TransitionKey
+from lerobot.processor.hil_processor import TELEOP_ACTION_KEY
+from lerobot.teleoperators import TeleopEvents
+from share.envs.manipulation_primitive.processor_steps import (
+    InterventionActionProcessorStep,
+    MatchTeleopToPolicyActionProcessorStep,
+    ToJointActionProcessorStep,
+)
+from share.envs.manipulation_primitive.task_frame import ControlMode, PolicyMode, TaskFrame
+from tests.share.envs.mock_pipeline_entities import MockDeltaTeleoperator, MockKinematicsSolver
+
+
+def _transition(action, observation=None, info=None, complementary_data=None):
+    return {
+        TransitionKey.OBSERVATION: observation or {},
+        TransitionKey.ACTION: action,
+        TransitionKey.REWARD: 0.0,
+        TransitionKey.DONE: False,
+        TransitionKey.TRUNCATED: False,
+        TransitionKey.INFO: info or {},
+        TransitionKey.COMPLEMENTARY_DATA: complementary_data or {},
+    }
+
+
+def test_to_joint_integrates_relative_task_frame_action_and_clamps_limits():
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        policy_mode=[PolicyMode.RELATIVE, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+        min_pose=[-0.2] * 6,
+        max_pose=[0.2] * 6,
+    )
+    step = ToJointActionProcessorStep(
+        is_task_frame_robot={"arm": False},
+        task_frame={"arm": frame},
+        kinematics={"arm": MockKinematicsSolver()},
+        joint_names={"arm": ["joint_1", "joint_2", "joint_3"]},
+        use_virtual_reference=True,
+    )
+
+    out1 = step(
+        _transition(
+            {"arm": torch.tensor([0.5, 0.0, 0.0, 0.0, 0.0, 0.0])},
+            observation={
+                "arm.x.ee_pos": 0.1,
+                "arm.y.ee_pos": 0.0,
+                "arm.z.ee_pos": 0.0,
+                "arm.wx.ee_pos": 0.0,
+                "arm.wy.ee_pos": 0.0,
+                "arm.wz.ee_pos": 0.0,
+            },
+        )
+    )
+    assert out1[TransitionKey.ACTION]["joint_2.pos"] == pytest.approx(0.2)
+
+    out2 = step(_transition({"arm": torch.tensor([-0.1, 0.0, 0.0, 0.0, 0.0, 0.0])}))
+    assert out2[TransitionKey.ACTION]["joint_2.pos"] == pytest.approx(0.1)
+
+
+def test_processor_chain_teleop_to_task_frame_to_joint_action():
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        policy_mode=[PolicyMode.RELATIVE, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+        min_pose=[-2.0] * 6,
+        max_pose=[2.0] * 6,
+    )
+
+    match = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": MockDeltaTeleoperator()},
+        task_frame={"arm": frame},
+    )
+    intervention = InterventionActionProcessorStep(task_frame={"arm": frame})
+    to_joint = ToJointActionProcessorStep(
+        is_task_frame_robot={"arm": False},
+        task_frame={"arm": frame},
+        kinematics={"arm": MockKinematicsSolver()},
+        joint_names={"arm": ["joint_1", "joint_2", "joint_3"]},
+        use_virtual_reference=False,
+    )
+
+    tr = _transition(
+        torch.tensor([0.0]),
+        observation={
+            "arm.x.ee_pos": 0.5,
+            "arm.y.ee_pos": 0.0,
+            "arm.z.ee_pos": 0.0,
+            "arm.wx.ee_pos": 0.0,
+            "arm.wy.ee_pos": 0.0,
+            "arm.wz.ee_pos": 0.0,
+        },
+        info={TeleopEvents.IS_INTERVENTION: True},
+        complementary_data={TELEOP_ACTION_KEY: {"arm": {"delta_x": 0.1}}},
+    )
+
+    out = to_joint(intervention(match(tr)))
+
+    assert out[TransitionKey.ACTION]["joint_1.pos"] == pytest.approx(0.0)
+    assert out[TransitionKey.ACTION]["joint_2.pos"] == pytest.approx(0.6)
+    assert out[TransitionKey.ACTION]["joint_3.pos"] == pytest.approx(0.0)


### PR DESCRIPTION
### Motivation
- Joint-only robots require a processor that converts full 6-DoF task-frame targets into joint commands by integrating relative axes, applying limits, and invoking IK so the pipeline can support non-task-frame hardware. 

### Description
- Implemented `ToJointActionProcessorStep` in `src/share/envs/manipulation_primitive/processor_steps.py` to integrate `PolicyMode.RELATIVE` POS axes into absolute task-frame targets using either the observation or a virtual reference, clamp targets against `TaskFrame.min_pose`/`max_pose`, call the configured IK solver, and remap IK outputs to `{joint_name}.pos` keys for downstream controllers. 
- Added `ToJointActionProcessorStep` to the manipulation primitive imports so the config can construct the step in the action pipeline (`src/share/envs/manipulation_primitive/config_manipulation_primitive.py`).
- Added tests in `tests/share/envs/test_to_joint_action_step.py` that verify integration + clamping + IK/key remapping and demonstrate chaining: `MatchTeleopToPolicyActionProcessorStep -> InterventionActionProcessorStep -> ToJointActionProcessorStep`.
- Adjusted assertions to use `pytest.approx` for numeric tolerance in the new tests.

### Testing
- Ran the focused test slice with `PYTHONPATH=src pytest -q tests/share/envs/test_match_teleop_to_policy_action_step.py tests/share/envs/test_intervention_action_step.py tests/share/envs/test_to_joint_action_step.py`. 
- All tests passed locally: `8 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c16f8458832099b6392b4d09b8d4)