### PR TITLE
Implement EPIC 5: env reset, task-frame naming normalization, and release-readiness tests

### DIFF
--- a/src/share/envs/ISSUE_BOARD_processor_pipeline.md
+++ b/src/share/envs/ISSUE_BOARD_processor_pipeline.md
@@ -177,7 +177,7 @@ When `is_task_frame_robot=False`:
 
 ### ENV-401: Complete `ManipulationPrimitive.reset` and clean env contract
 **Priority:** P1  
-**Status:** Todo  
+**Status:** Done  
 **Owner:** Unassigned
 
 #### Problem
@@ -199,7 +199,7 @@ When `is_task_frame_robot=False`:
 
 ### ENV-402: Normalize naming consistency (`min_pose`/`max_pose` vs docs naming)
 **Priority:** P1  
-**Status:** Todo  
+**Status:** Done  
 **Owner:** Unassigned
 
 #### Problem
@@ -221,7 +221,7 @@ Documentation references `min_target`/`max_target` while dataclass currently use
 
 ### ENV-501: Build compatibility matrix tests for release confidence
 **Priority:** P1  
-**Status:** Todo  
+**Status:** Done  
 **Owner:** Unassigned
 
 #### Scope
@@ -235,7 +235,7 @@ Documentation references `min_target`/`max_target` while dataclass currently use
 
 ### ENV-502: Add one end-to-end pipeline smoke test
 **Priority:** P2  
-**Status:** Todo  
+**Status:** Done  
 **Owner:** Unassigned
 
 #### Scope

--- a/src/share/envs/manipulation_primitive/env_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/env_manipulation_primitive.py
@@ -30,8 +30,8 @@ class ManipulationPrimitive(gymnasium.Env):
 
         self.current_step = 0
         self._motor_keys: set[str] = set()
-        self._action_length = dict[str, int] = {}
-        self._is_task_frame_robot = dict[str, bool] = check_task_frame_robot(robot_dict)
+        self._action_length: dict[str, int] = {}
+        self._is_task_frame_robot: dict[str, bool] = check_task_frame_robot(robot_dict)
         for name, robot in self.robot_dict.items():
             self._motor_keys.update([f"{name}.{key}" for key in robot._motors_ft])
             self._action_length[name] = len(robot.action_features)
@@ -67,7 +67,17 @@ class ManipulationPrimitive(gymnasium.Env):
         seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
-        pass
+        super().reset(seed=seed, options=options)
+
+        # Manipulation primitives do not execute an autonomous reset trajectory by default.
+        # We only re-send the configured task frame to robots that support task-frame commands.
+        for name, robot in self.robot_dict.items():
+            if self._is_task_frame_robot.get(name, False):
+                robot.set_task_frame(self.task_frame[name])
+
+        self.current_step = 0
+        obs = self._get_observation()
+        return obs, self._get_info()
 
     def render(self) -> None:
         import cv2
@@ -97,4 +107,3 @@ class ManipulationPrimitive(gymnasium.Env):
     @staticmethod
     def _get_info():
         return {TeleopEvents.IS_INTERVENTION: False}
-

--- a/src/share/envs/manipulation_primitive/processor_steps.py
+++ b/src/share/envs/manipulation_primitive/processor_steps.py
@@ -285,8 +285,8 @@ class InterventionActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _bound_differential_axis(frame: TaskFrame, axis: int, value: float) -> float:
-        if frame.min_pose is not None and frame.max_pose is not None:
-            scale = max(abs(frame.min_pose[axis]), abs(frame.max_pose[axis]))
+        if frame.min_target is not None and frame.max_target is not None:
+            scale = max(abs(frame.min_target[axis]), abs(frame.max_target[axis]))
             if scale > 0:
                 return math.tanh(value) * scale
         return math.tanh(value)
@@ -476,9 +476,9 @@ class ToJointActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _clamp_target(frame: TaskFrame, target: list[float]) -> list[float]:
-        if frame.min_pose is None or frame.max_pose is None:
+        if frame.min_target is None or frame.max_target is None:
             return target
-        return [max(frame.min_pose[i], min(frame.max_pose[i], target[i])) for i in range(len(target))]
+        return [max(frame.min_target[i], min(frame.max_target[i], target[i])) for i in range(len(target))]
 
     def transform_features(
         self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]

--- a/src/share/envs/manipulation_primitive/task_frame.py
+++ b/src/share/envs/manipulation_primitive/task_frame.py
@@ -114,23 +114,44 @@ class TaskFrame:
             "space": int(self.space),
             "origin": self.origin,
             "target": self.target,
-            "policy_mode": [int(policy_mode) for policy_mode in self.policy_mode],
+            "policy_mode": [int(policy_mode) if policy_mode is not None else None for policy_mode in self.policy_mode],
             "control_mode": [int(control_mode) for control_mode in self.control_mode],
-            "min_pose": self.min_pose,
-            "max_pose": self.max_pose,
+            "min_target": self.min_pose,
+            "max_target": self.max_pose,
         }
 
     @classmethod
     def from_dict(cls, raw: dict) -> TaskFrame:
+        min_target = raw.get("min_target", raw.get("min_pose"))
+        max_target = raw.get("max_target", raw.get("max_pose"))
         return cls(
             space=ControlSpace(raw["space"]),
             origin=raw.get("origin"),
             target=list(raw["target"]),
-            policy_mode=[PolicyMode(item) for item in raw["policy_mode"]],
+            policy_mode=[PolicyMode(item) if item is not None else None for item in raw["policy_mode"]],
             control_mode=[ControlMode(item) for item in raw["control_mode"]],
-            min_pose=list(raw["min_pose"]),
-            max_pose=list(raw["max_pose"]),
+            min_pose=list(min_target) if min_target is not None else None,
+            max_pose=list(max_target) if max_target is not None else None,
         )
+
+    @property
+    def min_target(self) -> list[float] | None:
+        """Canonical alias used by processor/docs for lower task-frame bounds."""
+        return self.min_pose
+
+    @min_target.setter
+    def min_target(self, value: list[float] | None) -> None:
+        self.min_pose = value
+
+    @property
+    def max_target(self) -> list[float] | None:
+        """Canonical alias used by processor/docs for upper task-frame bounds."""
+        return self.max_pose
+
+    @max_target.setter
+    def max_target(self, value: list[float] | None) -> None:
+        self.max_pose = value
+
 
 @dataclass(slots=True)
 class PrimitiveGraphConfig:

--- a/tests/share/envs/test_release_readiness_epic5.py
+++ b/tests/share/envs/test_release_readiness_epic5.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.processor.core import TransitionKey
+from lerobot.processor.hil_processor import TELEOP_ACTION_KEY
+from lerobot.teleoperators import TeleopEvents
+from share.envs.manipulation_primitive.env_manipulation_primitive import ManipulationPrimitive
+from share.envs.manipulation_primitive.processor_steps import (
+    InterventionActionProcessorStep,
+    MatchTeleopToPolicyActionProcessorStep,
+    ToJointActionProcessorStep,
+)
+from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpace, PolicyMode, TaskFrame
+from tests.share.envs.mock_pipeline_entities import (
+    MockAbsoluteJointTeleoperator,
+    MockDeltaTeleoperator,
+    MockKinematicsSolver,
+)
+
+
+@dataclass
+class _DummyRobot:
+    action_features: dict[str, type] = field(
+        default_factory=lambda: {
+            "joint_1.pos": float,
+            "joint_2.pos": float,
+            "joint_3.pos": float,
+        }
+    )
+    _motors_ft: dict[str, type] = field(default_factory=lambda: {"joint_1.pos": float, "joint_2.pos": float, "joint_3.pos": float})
+    is_connected: bool = False
+    last_action: np.ndarray | dict | None = None
+
+    def send_action(self, action):
+        self.last_action = action
+
+    def get_observation(self):
+        return {
+            "x.ee_pos": 0.0,
+            "y.ee_pos": 0.0,
+            "z.ee_pos": 0.0,
+            "wx.ee_pos": 0.0,
+            "wy.ee_pos": 0.0,
+            "wz.ee_pos": 0.0,
+        }
+
+    def disconnect(self):
+        self.is_connected = False
+
+
+@dataclass
+class _DummyTaskFrameRobot(_DummyRobot):
+    last_task_frame: TaskFrame | None = None
+
+    def set_task_frame(self, command: TaskFrame):
+        self.last_task_frame = command
+
+
+def _transition(action, observation=None, info=None, complementary_data=None):
+    return {
+        TransitionKey.OBSERVATION: observation or {},
+        TransitionKey.ACTION: action,
+        TransitionKey.REWARD: 0.0,
+        TransitionKey.DONE: False,
+        TransitionKey.TRUNCATED: False,
+        TransitionKey.INFO: info or {},
+        TransitionKey.COMPLEMENTARY_DATA: complementary_data or {},
+    }
+
+
+def test_env_reset_returns_obs_info():
+    frame = TaskFrame(target=[0.0] * 6, control_mode=[ControlMode.POS] * 6)
+    robot = _DummyTaskFrameRobot()
+    env = ManipulationPrimitive(task_frame={"arm": frame}, robot_dict={"arm": robot}, cameras={})
+
+    obs, info = env.reset()
+
+    assert isinstance(obs, dict)
+    assert info == {TeleopEvents.IS_INTERVENTION: False}
+    assert robot.last_task_frame is frame
+    assert env.current_step == 0
+
+
+def test_env_step_after_reset_smoke():
+    frame = TaskFrame(target=[0.0] * 6, control_mode=[ControlMode.POS] * 6)
+    robot = _DummyTaskFrameRobot()
+    env = ManipulationPrimitive(task_frame={"arm": frame}, robot_dict={"arm": robot}, cameras={})
+
+    env.reset()
+    obs, reward, terminated, truncated, info = env.step(np.array([0.1, 0.2, 0.3], dtype=np.float32))
+
+    assert isinstance(obs, dict)
+    assert reward == 0.0
+    assert terminated is False
+    assert truncated is False
+    assert info == {TeleopEvents.IS_INTERVENTION: False}
+    assert np.allclose(robot.last_action, np.array([0.1, 0.2, 0.3], dtype=np.float32))
+
+
+def test_task_frame_serialization_deserialization_compatibility_for_target_limits():
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        control_mode=[ControlMode.POS] * 6,
+        min_pose=[-1.0] * 6,
+        max_pose=[1.0] * 6,
+    )
+
+    raw = frame.to_dict()
+    decoded = TaskFrame.from_dict(raw)
+    assert decoded.min_target == [-1.0] * 6
+    assert decoded.max_target == [1.0] * 6
+
+    legacy_raw = {
+        "space": int(ControlSpace.TASK),
+        "origin": [0.0] * 6,
+        "target": [0.0] * 6,
+        "policy_mode": [int(PolicyMode.ABSOLUTE)] * 6,
+        "control_mode": [int(ControlMode.POS)] * 6,
+        "min_pose": [-2.0] * 6,
+        "max_pose": [2.0] * 6,
+    }
+    decoded_legacy = TaskFrame.from_dict(legacy_raw)
+    assert decoded_legacy.min_target == [-2.0] * 6
+    assert decoded_legacy.max_target == [2.0] * 6
+
+
+@pytest.mark.parametrize(
+    "teleop,space,policy_mode,requires_kinematics",
+    [
+        (MockDeltaTeleoperator(), ControlSpace.TASK, PolicyMode.RELATIVE, False),
+        (MockAbsoluteJointTeleoperator(), ControlSpace.TASK, PolicyMode.ABSOLUTE, True),
+        (MockDeltaTeleoperator(), ControlSpace.JOINT, PolicyMode.ABSOLUTE, True),
+    ],
+)
+def test_compatibility_matrix_pipeline_branching(teleop, space, policy_mode, requires_kinematics):
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        space=space,
+        policy_mode=[policy_mode, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+    )
+
+    match_step = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": teleop},
+        task_frame={"arm": frame},
+        kinematics={"arm": MockKinematicsSolver()} if requires_kinematics else {},
+    )
+
+    teleop_action = {"delta_x": 0.1} if isinstance(teleop, MockDeltaTeleoperator) else {"joint_1.pos": 1.0, "joint_2.pos": 2.0, "joint_3.pos": 3.0}
+
+    tr = _transition(
+        torch.tensor([0.0]),
+        complementary_data={TELEOP_ACTION_KEY: {"arm": teleop_action}},
+    )
+    out = match_step(tr)
+    converted = out[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+    assert isinstance(converted, torch.Tensor)
+    assert converted.numel() == frame.policy_action_dim
+
+
+def test_end_to_end_pipeline_smoke_with_single_step_call():
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        policy_mode=[PolicyMode.RELATIVE, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+        min_pose=[-2.0] * 6,
+        max_pose=[2.0] * 6,
+    )
+
+    env = ManipulationPrimitive(task_frame={"arm": frame}, robot_dict={"arm": _DummyRobot()}, cameras={})
+    env.reset()
+
+    match = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": MockDeltaTeleoperator()},
+        task_frame={"arm": frame},
+    )
+    intervention = InterventionActionProcessorStep(task_frame={"arm": frame})
+    to_joint = ToJointActionProcessorStep(
+        is_task_frame_robot={"arm": False},
+        task_frame={"arm": frame},
+        kinematics={"arm": MockKinematicsSolver()},
+        joint_names={"arm": ["joint_1", "joint_2", "joint_3"]},
+    )
+
+    tr = _transition(
+        torch.tensor([0.0]),
+        observation={
+            "arm.x.ee_pos": 0.2,
+            "arm.y.ee_pos": 0.0,
+            "arm.z.ee_pos": 0.0,
+            "arm.wx.ee_pos": 0.0,
+            "arm.wy.ee_pos": 0.0,
+            "arm.wz.ee_pos": 0.0,
+        },
+        info={TeleopEvents.IS_INTERVENTION: True},
+        complementary_data={TELEOP_ACTION_KEY: {"arm": {"delta_x": 0.1}}},
+    )
+
+    processed = to_joint(intervention(match(tr)))
+    low_level_action = np.array([processed[TransitionKey.ACTION][f"joint_{i}.pos"] for i in [1, 2, 3]], dtype=np.float32)
+
+    obs, reward, terminated, truncated, info = env.step(low_level_action)
+
+    assert isinstance(obs, dict)
+    assert reward == 0.0
+    assert terminated is False and truncated is False
+    assert info == {TeleopEvents.IS_INTERVENTION: False}


### PR DESCRIPTION
### Motivation
- Complete EPIC 5 to get the manipulation-primitive action/ENV pipeline release-ready by implementing `reset` behavior and finishing naming-consistency work described in the issue board. 
- Normalize task-frame limit naming to match docs and processors while preserving backward compatibility with older payloads. 
- Add automated tests that validate reset semantics, processor branching, serialization compatibility, and a simple end-to-end smoke flow.

### Description
- Implemented a minimal, gym-compatible reset flow in `ManipulationPrimitive.reset` that calls `super().reset(...)`, re-sends the configured `TaskFrame` only to robots that support task-frame commands, resets `current_step`, and returns `(obs, info)` (`src/share/envs/manipulation_primitive/env_manipulation_primitive.py`).
- Fixed invalid typed-assignment initializations in `ManipulationPrimitive.__init__` that caused runtime `TypeError` during environment construction by using proper annotation syntax (`_action_length: dict[str, int]` and `_is_task_frame_robot: dict[str, bool]`).
- Normalized task-frame limit naming by introducing canonical `min_target`/`max_target` aliases on `TaskFrame` while keeping `min_pose`/`max_pose` as the dataclass fields for backward compatibility; updated `to_dict`/`from_dict` to emit `min_target`/`max_target` and accept legacy `min_pose`/`max_pose`, and made `policy_mode` serialization robust to `None` entries (`src/share/envs/manipulation_primitive/task_frame.py`).
- Updated processor logic to use the canonical aliases for differential-axis scaling and clamping in both `InterventionActionProcessorStep` and `ToJointActionProcessorStep` (`src/share/envs/manipulation_primitive/processor_steps.py`).
- Added a release-readiness test suite `tests/share/envs/test_release_readiness_epic5.py` that covers `reset` contract, step-after-reset smoke, serialization/deserialization compatibility for limits, compatibility-matrix pipeline branching across teleop/space modes, and a single-step end-to-end smoke test using mocks. 
- Marked the relevant EPIC tickets as Done in the local issue board (`src/share/envs/ISSUE_BOARD_processor_pipeline.md`).

### Testing
- Ran the focused test set with `PYTHONPATH=src pytest tests/share/envs/test_release_readiness_epic5.py tests/share/envs/test_to_joint_action_step.py tests/share/envs/test_match_teleop_to_policy_action_step.py tests/share/envs/test_intervention_action_step.py tests/share/envs/test_task_frame_action_dim.py tests/share/envs/test_mock_pipeline_entities.py -q` and observed `21 passed`.
- Unit tests exercised FK/IK mock behavior, policy action dimension inference, teleop->policy and policy->task-frame conversion, target clamping/scaling, and the new `reset` behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c435f8048320ae8956319cd39ff5)