### PR TITLE
Add EPIC G issue board and complex kinematics mocks + tests for manipulation-primitive pipeline

### DIFF
--- a/src/share/envs/ISSUE_BOARD_processor_pipeline.md
+++ b/src/share/envs/ISSUE_BOARD_processor_pipeline.md
@@ -318,3 +318,136 @@ Upcoming processor-step tests require a deterministic and invertible kinematics 
 - Unit tests green for validation + manifold projections + conversion steps.
 - One end-to-end smoke test green.
 - Documentation and config naming aligned.
+
+## EPIC G — Missing Env Processor Implementations (Manipulation Primitive)
+
+### Gap Snapshot
+The current manipulation-primitive pipeline references several processor steps in `config_manipulation_primitive.py` that are not yet implemented in `src/share/envs/manipulation_primitive` and/or not wired through explicit imports. This epic tracks closing that gap end-to-end:
+- `JointsToEEObservation`
+- `RelativeFrameObservationProcessor`
+- `RelativeFrameActionProcessor`
+- `RobotActionToPolicyActionProcessorStep`
+- `VanillaObservationProcessorStep` wiring consistency
+
+---
+
+### ENV-701: Implement `JointsToEEObservation` for manipulation-primitive env pipeline
+**Priority:** P0  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Scope
+- Add a processor step that reads robot joint observations and appends `{robot}.{x,y,z,wx,wy,wz}.ee_pos`.
+- Support multi-robot dict input and configured joint name ordering.
+- Use deterministic FK from configured kinematics solver.
+
+#### Acceptance Criteria
+- For a fixed joint vector, generated EE observation is deterministic.
+- Missing joint keys fail with descriptive errors.
+- Works with batched and non-batched transition dicts.
+
+#### Tests
+- `test_joints_to_ee_observation_adds_expected_ee_pose_keys`
+- `test_joints_to_ee_observation_raises_on_missing_joint_key`
+
+---
+
+### ENV-702: Implement `RelativeFrameObservationProcessor`
+**Priority:** P0  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Scope
+- Convert absolute EE observations into frame-relative values using a per-episode reference frame.
+- Reset reference frame on processor reset.
+- Support per-robot enable flags.
+
+#### Acceptance Criteria
+- First frame defines reference origin.
+- Subsequent frames produce consistent relative offsets for translational + rotational channels.
+- Disabled robots pass through unchanged.
+
+#### Tests
+- `test_relative_frame_observation_processor_tracks_per_robot_reference`
+- `test_relative_frame_observation_processor_reset_reinitializes_reference`
+
+---
+
+### ENV-703: Implement `RelativeFrameActionProcessor`
+**Priority:** P0  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Scope
+- Transform action targets between world-frame and task-relative frame as configured.
+- Ensure compatibility with intervention-generated full task-frame actions.
+- Preserve non-EE and gripper channels.
+
+#### Acceptance Criteria
+- Relative-frame transform is invertible for deterministic fixtures.
+- Axis ordering remains consistent with task-frame definition.
+
+#### Tests
+- `test_relative_frame_action_processor_transforms_kinematic_axes_only`
+- `test_relative_frame_action_processor_is_noop_when_disabled`
+
+---
+
+### ENV-704: Implement/confirm `RobotActionToPolicyActionProcessorStep` bridge wiring
+**Priority:** P0  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Scope
+- Ensure final action dict -> tensor conversion in manipulation primitive uses stable motor ordering.
+- Validate mismatch handling for missing/extra keys.
+- Ensure compatibility with `ToJointActionProcessorStep` outputs.
+
+#### Acceptance Criteria
+- Output tensor shape/order deterministic across runs.
+- Errors identify robot and key mismatch clearly.
+
+#### Tests
+- `test_robot_action_to_policy_action_processor_stable_joint_order`
+- `test_robot_action_to_policy_action_processor_missing_joint_key_error`
+
+---
+
+### ENV-705: Resolve `VanillaObservationProcessorStep` source-of-truth + import contract
+**Priority:** P1  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Scope
+- Decide canonical implementation path (existing lerobot processor vs share wrapper).
+- Remove ambiguous/implicit imports in manipulation-primitive config.
+- Add explicit typing and transition contracts.
+
+#### Acceptance Criteria
+- `ManipulationPrimitiveConfig.make_env_processor` constructs without unresolved processor symbols.
+- Observation feature transform remains backward compatible.
+
+#### Tests
+- `test_make_env_processor_constructs_with_all_required_processors`
+- `test_vanilla_observation_processor_feature_contract_regression`
+
+---
+
+### ENV-706: End-to-end kinematic observation transformation regression suite
+**Priority:** P0  
+**Status:** Todo  
+**Owner:** Unassigned
+
+#### Scope
+- Add a richer mock robot fixture with joint, velocity, current, and EE channels.
+- Add deterministic complex FK/IK mock to validate transforms.
+- Cover both direct FK observation generation and downstream action integration consumers.
+
+#### Acceptance Criteria
+- Kinematic observation transformation tests run fully offline.
+- FK/IK round-trip checks remain numerically stable.
+
+#### Tests
+- `test_complex_mock_robot_observation_matches_complex_fk_mapping`
+- `test_match_step_uses_complex_fk_for_relative_kinematic_channels`
+- `test_to_joint_step_consumes_ee_observation_for_relative_integration`

--- a/tests/share/envs/mock_pipeline_entities.py
+++ b/tests/share/envs/mock_pipeline_entities.py
@@ -2,6 +2,41 @@ from dataclasses import dataclass, field
 
 
 @dataclass
+class MockComplexObservationRobot:
+    """Robot stub emitting a richer observation dictionary for env-pipeline tests."""
+
+    name: str = "mock_complex_robot"
+    joint_names: list[str] = field(default_factory=lambda: ["joint_1", "joint_2", "joint_3"])
+
+    def get_observation(self, prefix: str = "arm") -> dict[str, float]:
+        joints = {"joint_1": 0.35, "joint_2": -0.25, "joint_3": 0.55}
+        ee_x = 0.5 * joints["joint_1"] + 0.2 * joints["joint_2"] - 0.1 * joints["joint_3"]
+        ee_y = -0.3 * joints["joint_1"] + 0.4 * joints["joint_2"] + 0.2 * joints["joint_3"]
+        ee_z = joints["joint_1"] + joints["joint_2"] + joints["joint_3"]
+        ee_wx = 0.1 * joints["joint_1"]
+        ee_wy = -0.05 * joints["joint_2"]
+        ee_wz = 0.2 * joints["joint_3"]
+
+        return {
+            f"{prefix}.joint_1.pos": joints["joint_1"],
+            f"{prefix}.joint_2.pos": joints["joint_2"],
+            f"{prefix}.joint_3.pos": joints["joint_3"],
+            f"{prefix}.joint_1.vel": 0.03,
+            f"{prefix}.joint_2.vel": -0.01,
+            f"{prefix}.joint_3.vel": 0.02,
+            f"{prefix}.joint_1.current": 0.4,
+            f"{prefix}.joint_2.current": 0.2,
+            f"{prefix}.joint_3.current": 0.1,
+            f"{prefix}.x.ee_pos": ee_x,
+            f"{prefix}.y.ee_pos": ee_y,
+            f"{prefix}.z.ee_pos": ee_z,
+            f"{prefix}.wx.ee_pos": ee_wx,
+            f"{prefix}.wy.ee_pos": ee_wy,
+            f"{prefix}.wz.ee_pos": ee_wz,
+        }
+
+
+@dataclass
 class MockJointOnlyRobot:
     """Minimal robot stub without task-frame capability."""
 
@@ -71,4 +106,33 @@ class MockKinematicsSolver:
             self.joint_names[0]: y,
             self.joint_names[1]: x - y - z,
             self.joint_names[2]: z,
+        }
+
+
+@dataclass
+class MockComplexKinematicsSolver(MockKinematicsSolver):
+    """Kinematics mock with a richer affine mapping for FK/IK tests."""
+
+    def forward_kinematics(self, joint_positions: dict[str, float]) -> list[float]:
+        q1 = joint_positions[self.joint_names[0]]
+        q2 = joint_positions[self.joint_names[1]]
+        q3 = joint_positions[self.joint_names[2]]
+        return [
+            0.5 * q1 + 0.2 * q2 - 0.1 * q3,
+            -0.3 * q1 + 0.4 * q2 + 0.2 * q3,
+            q1 + q2 + q3,
+            0.1 * q1,
+            -0.05 * q2,
+            0.2 * q3,
+        ]
+
+    def inverse_kinematics(self, pose: list[float]) -> dict[str, float]:
+        x, y, z, _, _, _ = pose
+        q2 = (5.0 * x + y + 0.1 * z) / 2.7
+        q1 = 2.0 * x - 0.4 * q2 + 0.2 * z
+        q3 = z - q1 - q2
+        return {
+            self.joint_names[0]: q1,
+            self.joint_names[1]: q2,
+            self.joint_names[2]: q3,
         }

--- a/tests/share/envs/test_match_teleop_to_policy_action_step.py
+++ b/tests/share/envs/test_match_teleop_to_policy_action_step.py
@@ -6,6 +6,8 @@ from share.envs.manipulation_primitive.processor_steps import MatchTeleopToPolic
 from share.envs.manipulation_primitive.task_frame import ControlMode, ControlSpace, PolicyMode, TaskFrame
 from tests.share.envs.mock_pipeline_entities import (
     MockAbsoluteJointTeleoperator,
+    MockComplexKinematicsSolver,
+    MockComplexObservationRobot,
     MockDeltaTeleoperator,
     MockKinematicsSolver,
 )
@@ -106,3 +108,39 @@ def test_absolute_joint_teleop_uses_fk_and_relative_modes():
 
     assert torch.allclose(first_val, torch.tensor([0.0]))
     assert torch.allclose(second_val, torch.tensor([0.5]))
+
+
+def test_match_step_uses_complex_fk_for_relative_kinematic_channels():
+    robot = MockComplexObservationRobot()
+    obs = robot.get_observation(prefix="arm")
+
+    step = MatchTeleopToPolicyActionProcessorStep(
+        teleoperators={"arm": MockAbsoluteJointTeleoperator()},
+        task_frame={
+            "arm": TaskFrame(
+                policy_mode=[PolicyMode.RELATIVE, PolicyMode.RELATIVE, None, None, None, None],
+                control_mode=[ControlMode.POS] * 6,
+                target=[0.0] * 6,
+                space=ControlSpace.TASK,
+            )
+        },
+        kinematics={"arm": MockComplexKinematicsSolver()},
+    )
+
+    joint_action_1 = {"joint_1.pos": obs["arm.joint_1.pos"], "joint_2.pos": obs["arm.joint_2.pos"], "joint_3.pos": obs["arm.joint_3.pos"]}
+    out1 = step(_transition_with_teleop_action("arm", joint_action_1))
+    val1 = out1[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+    assert torch.allclose(val1, torch.tensor([0.0, 0.0]))
+
+    joint_action_2 = {
+        "joint_1.pos": joint_action_1["joint_1.pos"] + 0.1,
+        "joint_2.pos": joint_action_1["joint_2.pos"] - 0.05,
+        "joint_3.pos": joint_action_1["joint_3.pos"] + 0.02,
+    }
+    out2 = step(_transition_with_teleop_action("arm", joint_action_2))
+    val2 = out2[TransitionKey.COMPLEMENTARY_DATA][TELEOP_ACTION_KEY]["arm"]
+
+    # Expected deltas under MockComplexKinematicsSolver.forward_kinematics.
+    expected_dx = 0.5 * 0.1 + 0.2 * (-0.05) - 0.1 * 0.02
+    expected_dy = -0.3 * 0.1 + 0.4 * (-0.05) + 0.2 * 0.02
+    assert torch.allclose(val2, torch.tensor([expected_dx, expected_dy], dtype=torch.float32), atol=1e-6)

--- a/tests/share/envs/test_mock_pipeline_entities.py
+++ b/tests/share/envs/test_mock_pipeline_entities.py
@@ -4,6 +4,8 @@ from share.envs.utils import check_delta_teleoperator, check_task_frame_robot
 
 from tests.share.envs.mock_pipeline_entities import (
     MockAbsoluteJointTeleoperator,
+    MockComplexKinematicsSolver,
+    MockComplexObservationRobot,
     MockDeltaTeleoperator,
     MockJointOnlyRobot,
     MockKinematicsSolver,
@@ -42,3 +44,23 @@ def test_mock_kinematics_solver_is_deterministic_for_fk_and_ik():
 
     assert pose == pytest.approx([0.4, 0.2, -0.1, 0.04, 0.02, -0.01])
     assert roundtrip_joints == pytest.approx(joints)
+
+
+def test_complex_mock_robot_observation_matches_complex_fk_mapping():
+    robot = MockComplexObservationRobot()
+    solver = MockComplexKinematicsSolver()
+
+    obs = robot.get_observation(prefix="arm")
+    joints = {
+        "joint_1": obs["arm.joint_1.pos"],
+        "joint_2": obs["arm.joint_2.pos"],
+        "joint_3": obs["arm.joint_3.pos"],
+    }
+
+    pose = solver.forward_kinematics(joints)
+    assert obs["arm.x.ee_pos"] == pytest.approx(pose[0])
+    assert obs["arm.y.ee_pos"] == pytest.approx(pose[1])
+    assert obs["arm.z.ee_pos"] == pytest.approx(pose[2])
+    assert obs["arm.wx.ee_pos"] == pytest.approx(pose[3])
+    assert obs["arm.wy.ee_pos"] == pytest.approx(pose[4])
+    assert obs["arm.wz.ee_pos"] == pytest.approx(pose[5])

--- a/tests/share/envs/test_to_joint_action_step.py
+++ b/tests/share/envs/test_to_joint_action_step.py
@@ -10,7 +10,12 @@ from share.envs.manipulation_primitive.processor_steps import (
     ToJointActionProcessorStep,
 )
 from share.envs.manipulation_primitive.task_frame import ControlMode, PolicyMode, TaskFrame
-from tests.share.envs.mock_pipeline_entities import MockDeltaTeleoperator, MockKinematicsSolver
+from tests.share.envs.mock_pipeline_entities import (
+    MockComplexKinematicsSolver,
+    MockComplexObservationRobot,
+    MockDeltaTeleoperator,
+    MockKinematicsSolver,
+)
 
 
 def _transition(action, observation=None, info=None, complementary_data=None):
@@ -101,3 +106,45 @@ def test_processor_chain_teleop_to_task_frame_to_joint_action():
     assert out[TransitionKey.ACTION]["joint_1.pos"] == pytest.approx(0.0)
     assert out[TransitionKey.ACTION]["joint_2.pos"] == pytest.approx(0.6)
     assert out[TransitionKey.ACTION]["joint_3.pos"] == pytest.approx(0.0)
+
+
+def test_to_joint_step_consumes_ee_observation_for_relative_integration():
+    robot = MockComplexObservationRobot()
+    obs = robot.get_observation(prefix="arm")
+
+    frame = TaskFrame(
+        target=[0.0] * 6,
+        policy_mode=[PolicyMode.RELATIVE, None, None, None, None, None],
+        control_mode=[ControlMode.POS] * 6,
+        min_pose=[-2.0] * 6,
+        max_pose=[2.0] * 6,
+    )
+    step = ToJointActionProcessorStep(
+        is_task_frame_robot={"arm": False},
+        task_frame={"arm": frame},
+        kinematics={"arm": MockComplexKinematicsSolver()},
+        joint_names={"arm": ["joint_1", "joint_2", "joint_3"]},
+        use_virtual_reference=False,
+    )
+
+    out = step(
+        _transition(
+            {"arm": torch.tensor([0.1, obs["arm.y.ee_pos"], obs["arm.z.ee_pos"], 0.0, 0.0, 0.0])},
+            observation={
+                "arm.x.ee_pos": obs["arm.x.ee_pos"],
+                "arm.y.ee_pos": obs["arm.y.ee_pos"],
+                "arm.z.ee_pos": obs["arm.z.ee_pos"],
+                "arm.wx.ee_pos": obs["arm.wx.ee_pos"],
+                "arm.wy.ee_pos": obs["arm.wy.ee_pos"],
+                "arm.wz.ee_pos": obs["arm.wz.ee_pos"],
+            },
+        )
+    )
+
+    # Relative x axis should integrate against observed x.ee_pos before IK.
+    integrated_target = [obs["arm.x.ee_pos"] + 0.1, obs["arm.y.ee_pos"], obs["arm.z.ee_pos"], 0.0, 0.0, 0.0]
+    expected_joints = MockComplexKinematicsSolver().inverse_kinematics(integrated_target)
+    result = out[TransitionKey.ACTION]
+    assert result["joint_1.pos"] == pytest.approx(expected_joints["joint_1"], abs=1e-6)
+    assert result["joint_2.pos"] == pytest.approx(expected_joints["joint_2"], abs=1e-6)
+    assert result["joint_3.pos"] == pytest.approx(expected_joints["joint_3"], abs=1e-6)


### PR DESCRIPTION
### Motivation
- The manipulation-primitive processor pipeline references several missing processors (`JointsToEEObservation`, relative-frame processors, action bridge, and observation wiring) and needs a focused issue plan to complete them.
- Tests need richer, deterministic kinematics and observation fixtures so FK/IK-dependent pipeline logic can be verified offline. 

### Description
- Added an EPIC G section to `src/share/envs/ISSUE_BOARD_processor_pipeline.md` that enumerates ENV-701..ENV-706 covering the missing processors, acceptance criteria, and test goals. 
- Added `MockComplexObservationRobot` and `MockComplexKinematicsSolver` to `tests/share/envs/mock_pipeline_entities.py` to provide richer joint/EE/current observations and deterministic affine FK/IK behavior. 
- Extended/added unit tests in `tests/share/envs/test_mock_pipeline_entities.py`, `tests/share/envs/test_match_teleop_to_policy_action_step.py`, and `tests/share/envs/test_to_joint_action_step.py` to validate FK consistency, match-step relative deltas under complex FK, and integration of EE observations into `ToJointActionProcessorStep`. 

### Testing
- Ran the new/updated env pipeline unit tests with `PYTHONPATH=src pytest` covering the three modified test modules, and all tests passed (`11 passed`).
- The test run verifies deterministic FK/IK round-trips and that processor pipeline steps consume EE observations and kinematics as expected under the new mocks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d6e99a288320bfb80b30d926312a)