### PR TITLE
Add brief docstrings throughout manipulation_primitive env modules

### DIFF
--- a/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
@@ -50,6 +50,8 @@ from share.utils.kinematics import get_kinematics
 
 @dataclass
 class ImagePreprocessingConfig:
+    """Camera crop/resize options applied inside the env processor."""
+
     crop_params_dict: dict[str, tuple[int, int, int, int]] | None = None  # cam_name -> (top, left, height, width)
     resize_size: tuple[int, int] | None = None
     filter_keys: list[str] | None = None
@@ -96,12 +98,16 @@ class GripperConfig:
 
 @dataclass
 class EventConfig:
+    """Mappings from teleop inputs to structured intervention events."""
+
     key_mapping: dict[TeleopEvents, dict] = field(default_factory=lambda: {})
     foot_switch_mapping: dict[tuple[TeleopEvents], dict] = field(default_factory=lambda: {})
 
 
 @dataclass
 class HookConfig:
+    """Optional processor timing hook configuration."""
+
     time_env_processor: bool = False
     time_action_processor: bool = False
     log_every: int = 10
@@ -109,6 +115,8 @@ class HookConfig:
 
 @dataclass
 class ManipulationPrimitiveProcessorConfig:
+    """Top-level processor settings shared across robots and per robot."""
+
     # for all arms
     control_time_s: float = 10.0
     fps: float = 10.0
@@ -133,6 +141,7 @@ class ManipulationPrimitiveConfig(EnvConfig):
 
     @property
     def gym_kwargs(self) -> dict:
+        """Extra kwargs forwarded to gym environment creation."""
         return {}
 
     def make(
@@ -142,6 +151,7 @@ class ManipulationPrimitiveConfig(EnvConfig):
         cameras: dict[str, Camera],
         device: str = "cpu"
     ):
+        """Build the env and both processing pipelines."""
         self.validate(robot_dict, teleop_dict)
         self.infer_features(robot_dict)
 
@@ -153,6 +163,7 @@ class ManipulationPrimitiveConfig(EnvConfig):
         return env, env_processor, action_processor
 
     def make_action_processor(self, robot_dict, teleop_dict, device) -> DataProcessorPipeline:
+        """Create the action-side processing pipeline."""
         action_pipeline_steps = []
 
         # events
@@ -249,6 +260,7 @@ class ManipulationPrimitiveConfig(EnvConfig):
         )
 
     def make_env_processor(self, device) -> DataProcessorPipeline:
+        """Create the observation/reward-side processing pipeline."""
         env_pipeline_steps = []
 
         # obs is dict with keys {robot_name}.{axis/joint}.{pos/vel/ee_pos/ee_vel/ee_wrench} | {OBS_IMAGES}{camera_name}
@@ -333,6 +345,7 @@ class ManipulationPrimitiveConfig(EnvConfig):
         )
 
     def validate(self, robot_dict, teleop_dict):
+        """Validate modality compatibility and initialize kinematics state."""
         is_task_frame_robot = check_task_frame_robot(robot_dict)
         is_delta_teleoperator = check_delta_teleoperator(teleop_dict)
 
@@ -411,6 +424,7 @@ class ManipulationPrimitiveConfig(EnvConfig):
         # if gripper.enable but the robot has no GRIPPER_KEY action feature, disable
 
     def infer_features(self, robot_dict):
+        """Infer policy-visible feature specs from configured processors."""
         # process features with respective pipeline
         # get initial obs features from robot_dict instead
         env_processor = self.make_env_processor(device="cpu")
@@ -431,6 +445,5 @@ class ManipulationPrimitiveConfig(EnvConfig):
             if ft.type == FeatureType.VISUAL:
                 key = strip_prefix(key, PREFIXES_TO_STRIP)
                 self.features[f"{OBS_IMAGES}.{key}"] = PolicyFeature(type=FeatureType.VISUAL, shape=ft.shape)
-
 
 

--- a/src/share/envs/manipulation_primitive/env_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/env_manipulation_primitive.py
@@ -15,6 +15,7 @@ from ..utils import check_task_frame_robot
 
 
 class ManipulationPrimitive(gymnasium.Env):
+    """Minimal gym env wiring robots, cameras, and task-frame commands."""
 
     def __init__(
         self,
@@ -23,6 +24,7 @@ class ManipulationPrimitive(gymnasium.Env):
         cameras: dict[str, Camera],
         display_cameras: bool = False
     ):
+        """Initialize robot/camera handles and action slicing metadata."""
         self.robot_dict = robot_dict
         self.task_frame = task_frame
         self.cameras = cameras
@@ -37,6 +39,7 @@ class ManipulationPrimitive(gymnasium.Env):
             self._action_length[name] = len(robot.action_features)
 
     def step(self, action: np.ndarray | torch.Tensor) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, Any]]:
+        """Apply an action slice per robot and return fresh observations."""
         if isinstance(action, torch.Tensor):
             action = action.detach().cpu().numpy()
 
@@ -67,6 +70,7 @@ class ManipulationPrimitive(gymnasium.Env):
         seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
+        """Reset counters and resend configured task frames when supported."""
         super().reset(seed=seed, options=options)
 
         # Manipulation primitives do not execute an autonomous reset trajectory by default.
@@ -80,6 +84,7 @@ class ManipulationPrimitive(gymnasium.Env):
         return obs, self._get_info()
 
     def render(self) -> None:
+        """Display camera observations using OpenCV windows."""
         import cv2
         current_observation = self._get_observation()
         if current_observation is not None and "pixels" in current_observation:
@@ -88,11 +93,13 @@ class ManipulationPrimitive(gymnasium.Env):
             cv2.waitKey(1)
 
     def close(self) -> None:
+        """Disconnect any connected robots."""
         for robot_dict in self.robot_dict.values():
             if robot_dict.is_connected:
                 robot_dict.disconnect()
 
     def _get_observation(self):
+        """Collect camera pixels and robot observations into one dict."""
         obs_dict = {}
 
         for cam_key, cam in self.cameras.items():
@@ -106,4 +113,5 @@ class ManipulationPrimitive(gymnasium.Env):
 
     @staticmethod
     def _get_info():
+        """Return default per-step info payload."""
         return {TeleopEvents.IS_INTERVENTION: False}

--- a/src/share/envs/manipulation_primitive/processor_steps.py
+++ b/src/share/envs/manipulation_primitive/processor_steps.py
@@ -16,6 +16,8 @@ from share.envs.utils import check_delta_teleoperator
 
 
 def _euler_xyz_to_matrix(rx: float, ry: float, rz: float) -> list[list[float]]:
+    """Convert extrinsic XYZ Euler angles to a rotation matrix."""
+
     cx, sx = math.cos(rx), math.sin(rx)
     cy, sy = math.cos(ry), math.sin(ry)
     cz, sz = math.cos(rz), math.sin(rz)
@@ -31,6 +33,8 @@ def _euler_xyz_to_matrix(rx: float, ry: float, rz: float) -> list[list[float]]:
 @dataclass
 @ProcessorStepRegistry.register("match_teleop_to_policy_action")
 class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
+    """Map raw teleop commands into the policy learning-space action format."""
+
     teleoperators: dict[str, Any] = field(default_factory=dict)
     task_frame: dict[str, TaskFrame] = field(default_factory=dict)
     kinematics: dict[str, Any] = field(default_factory=dict)
@@ -41,9 +45,11 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
     _prev_fk_pose: dict[str, list[float]] = field(default_factory=dict, init=False)
 
     def __post_init__(self) -> None:
+        """Cache teleoperator modality flags for fast dispatch."""
         self._is_delta_teleoperator = check_delta_teleoperator(self.teleoperators)
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
+        """Rewrite complementary teleop actions using task-frame encodings."""
         new_transition = transition.copy()
         complementary_data = dict(new_transition.get(TransitionKey.COMPLEMENTARY_DATA) or {})
         teleop_action_dict = complementary_data.get(TELEOP_ACTION_KEY)
@@ -67,6 +73,7 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
         return new_transition
 
     def _map_delta_teleop(self, name: str, frame: TaskFrame, teleop_action: Any, transition: EnvTransition) -> torch.Tensor:
+        """Map Cartesian delta teleop input into learning-space values."""
         deltas = self._extract_delta_action(teleop_action)
 
         if frame.space == ControlSpace.JOINT:
@@ -91,6 +98,7 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
         return self._encode_learning_space(frame, source_pose)
 
     def _map_absolute_joint_teleop(self, name: str, frame: TaskFrame, teleop_action: Any) -> torch.Tensor:
+        """Map absolute joint teleop input into learning-space values."""
         joint_state = self._extract_joint_action(teleop_action)
         if frame.space == ControlSpace.JOINT:
             values = [joint_state.get(f"joint_{axis + 1}", 0.0) for axis in frame.learnable_axis_indices]
@@ -111,6 +119,7 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
         return self._encode_learning_space(frame, source)
 
     def _encode_learning_space(self, frame: TaskFrame, source_pose: list[float]) -> torch.Tensor:
+        """Encode a 6-DoF source pose into manifold-aware policy action vectors."""
         values: list[float] = []
         absolute_rot_axes = [
             axis
@@ -154,6 +163,7 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
         return torch.tensor(values, dtype=torch.float32)
 
     def _integration_base_pose(self, name: str, frame: TaskFrame, transition: EnvTransition) -> list[float]:
+        """Get pose baseline for integrating relative teleop commands."""
         use_virtual = self.use_virtual_reference[name] if isinstance(self.use_virtual_reference, dict) else self.use_virtual_reference
 
         # 1. Primary: Use the virtual reference if enabled and populated
@@ -180,6 +190,7 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
         return list(frame.target)
 
     def _require_solver(self, name: str) -> Any:
+        """Return configured kinematics solver for ``name`` or raise."""
         solver = self.kinematics.get(name)
         if solver is None:
             raise ValueError(f"Missing kinematics solver for '{name}'")
@@ -187,6 +198,7 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _extract_delta_action(teleop_action: Any) -> list[float]:
+        """Normalize teleop delta input into a 6-value Cartesian delta list."""
         if isinstance(teleop_action, dict):
             return [
                 float(teleop_action.get("delta_x", 0.0)),
@@ -200,6 +212,7 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _extract_joint_action(teleop_action: Any) -> dict[str, float]:
+        """Normalize teleop joint input into ``joint_name -> position``."""
         if isinstance(teleop_action, dict):
             joint_state: dict[str, float] = {}
             for k, v in teleop_action.items():
@@ -211,6 +224,7 @@ class MatchTeleopToPolicyActionProcessorStep(ProcessorStep):
     def transform_features(
         self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
     ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        """Leave feature specs unchanged."""
         return features
 
 
@@ -225,6 +239,7 @@ class InterventionActionProcessorStep(ProcessorStep):
     _intervention_occurred: bool = field(default=False, init=False)
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
+        """Select policy or teleop action source and emit full task-frame targets."""
         action = transition.get(TransitionKey.ACTION)
         if not isinstance(action, torch.Tensor):
             raise TypeError(f"Action should be a torch.Tensor, got {type(action)}")
@@ -262,6 +277,7 @@ class InterventionActionProcessorStep(ProcessorStep):
         return new_transition
 
     def _split_policy_action(self, action: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Split flat policy action tensor into per-robot slices."""
         policy_by_robot: dict[str, torch.Tensor] = {}
         idx = 0
         for name, frame in self.task_frame.items():
@@ -271,6 +287,7 @@ class InterventionActionProcessorStep(ProcessorStep):
         return policy_by_robot
 
     def _project_learning_action(self, frame: TaskFrame, encoded_action: Any) -> list[float]:
+        """Project encoded learning-space vectors into a full 6-DoF task target."""
         raw = torch.as_tensor(encoded_action, dtype=torch.float32).flatten().tolist()
 
         full_target = list(frame.target)
@@ -308,6 +325,7 @@ class InterventionActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _bound_differential_axis(frame: TaskFrame, axis: int, value: float) -> float:
+        """Bound velocity/force-like scalars with tanh and optional axis scaling."""
         if frame.min_target is not None and frame.max_target is not None:
             scale = max(abs(frame.min_target[axis]), abs(frame.max_target[axis]))
             if scale > 0:
@@ -315,6 +333,7 @@ class InterventionActionProcessorStep(ProcessorStep):
         return math.tanh(value)
 
     def _decode_absolute_rotation(self, absolute_rot_axes: list[int], raw: list[float]) -> tuple[list[float], int]:
+        """Decode manifold rotation chunks (S1/S2/SO3) into Euler XYZ angles."""
         rot = [0.0, 0.0, 0.0]
 
         if len(absolute_rot_axes) == 1:
@@ -348,6 +367,7 @@ class InterventionActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _rotation_6d_to_matrix(raw: list[float]) -> list[list[float]]:
+        """Convert 6D continuous rotation representation into a 3x3 matrix."""
         a1 = [raw[0], raw[1], raw[2]]
         a2 = [raw[3], raw[4], raw[5]]
 
@@ -379,6 +399,7 @@ class InterventionActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _matrix_to_euler_xyz(matrix: list[list[float]]) -> list[float]:
+        """Convert a rotation matrix into extrinsic XYZ Euler angles."""
         sy = max(-1.0, min(1.0, -matrix[2][0]))
         ry = math.asin(sy)
         cy = math.cos(ry)
@@ -395,9 +416,11 @@ class InterventionActionProcessorStep(ProcessorStep):
     def transform_features(
         self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
     ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        """Leave feature specs unchanged."""
         return features
 
     def reset(self) -> None:
+        """Clear intervention completion tracking state."""
         self._intervention_occurred = False
 
 
@@ -415,6 +438,7 @@ class ToJointActionProcessorStep(ProcessorStep):
     _virtual_task_pose: dict[str, list[float]] = field(default_factory=dict, init=False)
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
+        """Convert task-space actions to joint commands for joint-only robots."""
         action = transition.get(TransitionKey.ACTION)
         if not isinstance(action, dict):
             return transition
@@ -469,6 +493,7 @@ class ToJointActionProcessorStep(ProcessorStep):
         task_target: list[float],
         transition: EnvTransition,
     ) -> list[float]:
+        """Integrate relative POS axes on top of the current/base task pose."""
         base_pose = self._base_pose(name, frame, transition)
         out = list(task_target)
         for axis in frame.learnable_axis_indices:
@@ -477,6 +502,7 @@ class ToJointActionProcessorStep(ProcessorStep):
         return out
 
     def _base_pose(self, name: str, frame: TaskFrame, transition: EnvTransition) -> list[float]:
+        """Resolve integration base pose from virtual state, observation, or default target."""
         use_virtual = self.use_virtual_reference[name] if isinstance(self.use_virtual_reference, dict) else self.use_virtual_reference
         if use_virtual and name in self._virtual_task_pose:
             return list(self._virtual_task_pose[name])
@@ -499,6 +525,7 @@ class ToJointActionProcessorStep(ProcessorStep):
 
     @staticmethod
     def _clamp_target(frame: TaskFrame, target: list[float]) -> list[float]:
+        """Clamp task target to configured min/max bounds when available."""
         if frame.min_target is None or frame.max_target is None:
             return target
         return [max(frame.min_target[i], min(frame.max_target[i], target[i])) for i in range(len(target))]
@@ -506,4 +533,5 @@ class ToJointActionProcessorStep(ProcessorStep):
     def transform_features(
         self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
     ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        """Leave feature specs unchanged."""
         return features

--- a/src/share/envs/manipulation_primitive/task_frame.py
+++ b/src/share/envs/manipulation_primitive/task_frame.py
@@ -5,16 +5,22 @@ from enum import IntEnum
 
 
 class ControlSpace(IntEnum):
+    """Target command space used by a task frame."""
+
     JOINT = 0
     TASK = 1
 
 
 class PolicyMode(IntEnum):
+    """How policy outputs are interpreted for a learnable axis."""
+
     ABSOLUTE = 0
     RELATIVE = 1
 
 
 class ControlMode(IntEnum):
+    """Low-level command type applied on each axis."""
+
     POS = 0
     VEL = 1
     FORCE = 2
@@ -31,6 +37,7 @@ class TaskFrame:
     max_pose: list[float] | None = None  # 6-vector: max xyz (m), max extrinsic euler (rad)
 
     def __post_init__(self) -> None:
+        """Validate task-frame axis layout and mode compatibility."""
         width = len(self.target)
         if width == 0:
             raise ValueError("target must contain at least one axis")
@@ -59,10 +66,12 @@ class TaskFrame:
 
     @property
     def learnable_axis_indices(self) -> list[int]:
+        """Return axis indices controlled by policy outputs."""
         return [i for i, _policy_mode in enumerate(self.policy_mode) if _policy_mode is not None]
 
     @property
     def is_adaptive(self) -> bool:
+        """Whether at least one axis is policy-controlled."""
         return len(self.learnable_axis_indices) > 0
 
     @property
@@ -110,6 +119,7 @@ class TaskFrame:
         )
 
     def to_dict(self) -> dict:
+        """Serialize to a JSON-friendly dictionary."""
         return {
             "space": int(self.space),
             "origin": self.origin,
@@ -122,6 +132,7 @@ class TaskFrame:
 
     @classmethod
     def from_dict(cls, raw: dict) -> TaskFrame:
+        """Build a task frame from a serialized dictionary."""
         min_target = raw.get("min_target", raw.get("min_pose"))
         max_target = raw.get("max_target", raw.get("max_pose"))
         return cls(
@@ -141,6 +152,7 @@ class TaskFrame:
 
     @min_target.setter
     def min_target(self, value: list[float] | None) -> None:
+        """Set lower task-frame bounds using canonical alias."""
         self.min_pose = value
 
     @property
@@ -150,6 +162,7 @@ class TaskFrame:
 
     @max_target.setter
     def max_target(self, value: list[float] | None) -> None:
+        """Set upper task-frame bounds using canonical alias."""
         self.max_pose = value
 
 
@@ -161,6 +174,7 @@ class PrimitiveGraphConfig:
     nodes: list
 
     def __post_init__(self) -> None:
+        """Ensure primitive references and transitions are valid."""
         node_ids = {node.primitive_id for node in self.nodes}
         if self.start_primitive_id not in node_ids:
             raise ValueError("start_primitive_id must reference an existing primitive_id")
@@ -173,6 +187,7 @@ class PrimitiveGraphConfig:
                     )
 
     def node_by_id(self, primitive_id: str):
+        """Return the primitive node matching ``primitive_id``."""
         for node in self.nodes:
             if node.primitive_id == primitive_id:
                 return node


### PR DESCRIPTION
### Motivation
- Improve in-code discoverability by adding concise docstrings to the manipulation primitive environment package so enums, configs, processors and env lifecycle methods are self-documented.

### Description
- Added short docstrings to `src/share/envs/manipulation_primitive/task_frame.py` for enums (`ControlSpace`, `PolicyMode`, `ControlMode`), key `TaskFrame` properties/serializers, and `PrimitiveGraphConfig` validation helpers.
- Documented processor configuration dataclasses and pipeline factory/validation methods in `src/share/envs/manipulation_primitive/config_manipulation_primitive.py`.
- Added brief explanations to conversion helpers and processor step entry points in `src/share/envs/manipulation_primitive/processor_steps.py` (encoding/decoding, projection, clamping, feature transforms, etc.).
- Documented the environment lifecycle and helper methods in `src/share/envs/manipulation_primitive/env_manipulation_primitive.py` (`__init__`, `step`, `reset`, `render`, `close`, `_get_observation`, `_get_info`).

### Testing
- Ran an AST-based script that inspects top-level classes/functions and class methods across `src/share/envs/manipulation_primitive/*.py` to ensure each had a docstring, and the script reported no missing docstrings (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d8d13b8483208d3f46939b1fd721)