### PR TITLE
Implement MPN-101: MP-Net step orchestration with transition handling

### DIFF
--- a/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
@@ -1,19 +1,18 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import gymnasium as gym
 import numpy as np
 import torch
-from lerobot.cameras import Camera, make_cameras_from_configs
-
-from lerobot.teleoperators import Teleoperator, make_teleoperator_from_config
-
-from lerobot.robots import Robot, make_robot_from_config
-
-from share.envs.manipulation_primitive_net.config_manipulation_primitive_net import ManipulationPrimitiveNetConfig
+if TYPE_CHECKING:
+    from lerobot.cameras import Camera
+    from lerobot.teleoperators import Teleoperator
+    from lerobot.robots import Robot
+    from share.envs.manipulation_primitive_net.config_manipulation_primitive_net import ManipulationPrimitiveNetConfig
 
 
 class ManipulationPrimitiveNet(gym.Env):
-    def __init__(self, config: ManipulationPrimitiveNetConfig):
+    def __init__(self, config: "ManipulationPrimitiveNetConfig"):
+
         self.config = config
 
         # initialize hardware environments
@@ -24,36 +23,104 @@ class ManipulationPrimitiveNet(gym.Env):
         self._action_processors = {}
 
         for name, primitive in self.config.primitives.items():
-            env, env_processor, action_processor = primitive.make(robot_dict, teleop_dict, cameras, device=self.config.device)
+            env, env_processor, action_processor = primitive.make(robot_dict, teleop_dict, cameras, device=getattr(self.config, "device", "cpu"))
             self._envs[name] = env
             self._env_processors[name] = env_processor
             self._action_processors[name] = action_processor
 
-    def step(self, action: np.ndarray | torch.Tensor) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, Any]]:
-        pass
+        self._active_primitive = self.config.start_primitive
 
-    def connect(self) -> tuple[dict[str, Robot], dict[str, Teleoperator], dict[str, Camera]]:
-        assert self.robot is not None, "Robot config must be provided for real robot environment"
+    @staticmethod
+    def _evaluate_transition(transition: Any, obs: dict[str, np.ndarray], info: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+        """Normalize transition interfaces to a bool + metadata contract."""
+        if hasattr(transition, "evaluate"):
+            result = transition.evaluate(obs=obs, info=info)
+        elif hasattr(transition, "check"):
+            result = transition.check(obs=obs, info=info)
+        else:
+            raise AttributeError("Transition must define either `evaluate(obs, info)` or `check(obs, info)`")
+
+        if isinstance(result, bool):
+            return result, {}
+        if isinstance(result, tuple):
+            condition = bool(result[0])
+            metadata = result[1] if len(result) > 1 else {}
+            return condition, metadata or {}
+        if isinstance(result, dict):
+            return bool(result.get("condition_fulfilled", result.get("triggered", False))), result
+
+        raise TypeError(f"Unsupported transition evaluation output type: {type(result)!r}")
+
+    def step(self, action: np.ndarray | torch.Tensor) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, Any]]:
+        active = self._active_primitive
+        if active not in self._envs:
+            raise KeyError(f"Unknown active primitive '{active}'.")
+
+        obs, reward, terminated, truncated, info = self._envs[active].step(action)
+
+        transition_info = {
+            "from": active,
+            "to": active,
+            "reason": None,
+            "transition_name": None,
+            "transition_type": None,
+        }
+
+        for source, default_target, transition in self.config.transitions:
+            if source != active:
+                continue
+
+            fired, transition_metadata = self._evaluate_transition(transition=transition, obs=obs, info=info)
+            if not fired:
+                continue
+
+            transition_target = transition_metadata.get("next_primitive", default_target)
+            reward += float(transition_metadata.get("additional_reward", 0.0))
+            terminated = bool(terminated or transition_metadata.get("terminated", False))
+            truncated = bool(truncated or transition_metadata.get("truncated", False))
+
+            transition_info = {
+                "from": source,
+                "to": transition_target,
+                "reason": transition_metadata.get("reason", "transition_fired"),
+                "transition_name": transition_metadata.get("transition_name", transition.__class__.__name__),
+                "transition_type": transition_metadata.get("transition_type", transition.__class__.__name__),
+            }
+
+            self._active_primitive = transition_target
+            break
+
+        info = dict(info)
+        info["transition"] = transition_info
+        info["active_primitive"] = self._active_primitive
+
+        return obs, reward, terminated, truncated, info
+
+    def connect(self) -> tuple[dict[str, "Robot"], dict[str, "Teleoperator"], dict[str, "Camera"]]:
+        assert self.config.robot is not None, "Robot config must be provided for real robot environment"
+
+        from lerobot.cameras import make_cameras_from_configs
+        from lerobot.teleoperators import make_teleoperator_from_config
+        from lerobot.robots import make_robot_from_config
 
         # Handle multi robot configuration
         robot_dict = {}
-        for name in self.robot:
-            robot_dict[name] = make_robot_from_config(self.robot[name])
+        for name in self.config.robot:
+            robot_dict[name] = make_robot_from_config(self.config.robot[name])
             robot_dict[name].connect()
 
         # Handle multi teleop configuration
         teleop_dict = {}
-        for name in self.teleop:
-            teleop_dict[name] = make_teleoperator_from_config(self.teleop[name])
+        for name in self.config.teleop:
+            teleop_dict[name] = make_teleoperator_from_config(self.config.teleop[name])
             teleop_dict[name].connect()
 
         # Handle cameras
-        cameras = make_cameras_from_configs(self.cameras)
+        cameras = make_cameras_from_configs(self.config.cameras)
         for name in cameras:
             cameras[name].connect()
 
         return robot_dict, teleop_dict, cameras
-
 
 
 

--- a/tests/share/envs/test_manipulation_primitive_net_step.py
+++ b/tests/share/envs/test_manipulation_primitive_net_step.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from share.envs.manipulation_primitive_net.env_manipulation_primitive_net import ManipulationPrimitiveNet
+
+
+class DummyEnv:
+    def __init__(self, obs, reward=0.0, terminated=False, truncated=False, info=None):
+        self.obs = obs
+        self.reward = reward
+        self.terminated = terminated
+        self.truncated = truncated
+        self.info = info or {}
+        self.last_action = None
+
+    def step(self, action):
+        self.last_action = action
+        return self.obs, self.reward, self.terminated, self.truncated, dict(self.info)
+
+
+class StaticBoolTransition:
+    def __init__(self, should_fire: bool):
+        self.should_fire = should_fire
+
+    def check(self, obs, info):
+        return self.should_fire
+
+
+class RichTransition:
+    def evaluate(self, obs, info):
+        return True, {
+            "next_primitive": "place",
+            "additional_reward": 1.75,
+            "terminated": True,
+            "reason": "success",
+            "transition_name": "success_edge",
+            "transition_type": "threshold",
+        }
+
+
+def _make_net(envs, transitions, active="pick"):
+    net = ManipulationPrimitiveNet.__new__(ManipulationPrimitiveNet)
+    net._envs = envs
+    net._active_primitive = active
+    net.config = SimpleNamespace(transitions=transitions)
+    return net
+
+
+def test_mp_net_step_executes_active_primitive():
+    pick_env = DummyEnv(obs={"obs": np.array([1.0])}, reward=0.5)
+    place_env = DummyEnv(obs={"obs": np.array([2.0])}, reward=5.0)
+    net = _make_net(
+        envs={"pick": pick_env, "place": place_env},
+        transitions=[("pick", "place", StaticBoolTransition(False))],
+    )
+
+    obs, reward, terminated, truncated, info = net.step(np.array([0.2, -0.1]))
+
+    assert np.allclose(obs["obs"], np.array([1.0]))
+    assert reward == 0.5
+    assert not terminated
+    assert not truncated
+    assert pick_env.last_action is not None
+    assert place_env.last_action is None
+    assert net._active_primitive == "pick"
+    assert info["active_primitive"] == "pick"
+    assert info["transition"]["from"] == "pick"
+    assert info["transition"]["to"] == "pick"
+
+
+def test_mp_net_step_switches_primitive_when_transition_fires():
+    pick_env = DummyEnv(obs={"obs": np.array([1.0])}, reward=0.25)
+    net = _make_net(
+        envs={"pick": pick_env, "place": DummyEnv(obs={"obs": np.array([2.0])})},
+        transitions=[("pick", "place", StaticBoolTransition(True))],
+    )
+
+    _, reward, terminated, truncated, info = net.step(np.array([0.0]))
+
+    assert reward == 0.25
+    assert not terminated
+    assert not truncated
+    assert net._active_primitive == "place"
+    assert info["active_primitive"] == "place"
+    assert info["transition"]["from"] == "pick"
+    assert info["transition"]["to"] == "place"
+    assert info["transition"]["reason"] == "transition_fired"
+
+
+def test_mp_net_step_applies_transition_reward_and_done_flags():
+    pick_env = DummyEnv(obs={"obs": np.array([1.0])}, reward=0.5)
+    net = _make_net(
+        envs={"pick": pick_env, "place": DummyEnv(obs={"obs": np.array([2.0])})},
+        transitions=[("pick", "place", RichTransition())],
+    )
+
+    _, reward, terminated, truncated, info = net.step(np.array([0.0]))
+
+    assert reward == 2.25
+    assert terminated
+    assert not truncated
+    assert net._active_primitive == "place"
+    assert info["transition"]["from"] == "pick"
+    assert info["transition"]["to"] == "place"
+    assert info["transition"]["reason"] == "success"
+    assert info["transition"]["transition_name"] == "success_edge"
+    assert info["transition"]["transition_type"] == "threshold"


### PR DESCRIPTION
### Motivation
- The MP-Net lacked a runtime `step` entrypoint so primitives could not be chained or transitions evaluated, blocking multi-step rollouts and net-level reward shaping.  
- Implement MPN-101 to enable active-primitive execution, transition evaluation, and gym-compatible return semantics so MP-Net can orchestrate primitive graphs at runtime.

### Description
- Implemented `ManipulationPrimitiveNet.step` to execute the action on the current active primitive, evaluate configured outgoing transitions, apply transition-provided reward and done/truncated overrides, update `self._active_primitive`, and return `(obs, reward, terminated, truncated, info)`; changes in `src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py`.  
- Added `_evaluate_transition` helper to normalize transition outputs from either `check(...)` or `evaluate(...)` to a `(bool, metadata)` contract and support rich metadata like `next_primitive`, `additional_reward`, `terminated`, `reason`, and transition naming.  
- Initialize `self._active_primitive` from config `start_primitive`, add transition diagnostics into `info` (`from`, `to`, `reason`, `transition_name`, `transition_type`, `active_primitive`), and make `connect()` use `self.config` with lazy imports for runtime wiring.  
- Added unit tests exercising acceptance criteria in `tests/share/envs/test_manipulation_primitive_net_step.py` that cover active-primitive execution, primitive switching when a transition fires, and applying transition reward/done flags.

### Testing
- Ran unit tests: `PYTHONPATH=src pytest -q tests/share/envs/test_manipulation_primitive_net_step.py` which executed the three new tests and they all passed (`3 passed`).  
- Performed a bytecode/compile check with `PYTHONPATH=src python -m compileall src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py tests/share/envs/test_manipulation_primitive_net_step.py` which completed successfully.  
- Modified files: `src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py` (step implementation, transition normalization, wiring) and added tests at `tests/share/envs/test_manipulation_primitive_net_step.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e3f8360c8320b09185c15828a19f)