### PR TITLE
Implement MPN-102: coherent reset semantics for ManipulationPrimitiveNet

### DIFF
--- a/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
@@ -16,6 +16,7 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
     start_primitive: str
     primitives: dict[str, ManipulationPrimitiveConfig]
     transitions: list[tuple[str, str, MP_Transition]]
+    reset_primitives: list[str] = field(default_factory=list)
 
     fps: int = 10
     robot: RobotConfig | dict[str, RobotConfig] | None = None
@@ -28,5 +29,4 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
         self.teleop = self.teleop if isinstance(self.teleop, dict) else {DEFAULT_ROBOT_NAME: self.teleop}
         for name in self.robot:
             self.robot[name].cameras = {}
-
 

--- a/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
@@ -29,6 +29,72 @@ class ManipulationPrimitiveNet(gym.Env):
             self._action_processors[name] = action_processor
 
         self._active_primitive = self.config.start_primitive
+        self._last_reset_info: dict[str, Any] = {}
+        self._episode_step_count = 0
+
+
+    def _resolve_reset_start(self) -> str:
+        if self.config.start_primitive in self._envs:
+            return self.config.start_primitive
+
+        for reset_primitive in getattr(self.config, "reset_primitives", []):
+            if reset_primitive in self._envs:
+                return reset_primitive
+
+        raise KeyError(
+            f"Unable to resolve reset start primitive: start_primitive='{self.config.start_primitive}' "
+            "and no configured reset primitive exists in env map."
+        )
+
+    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None) -> tuple[dict[str, np.ndarray], dict[str, Any]]:
+        super().reset(seed=seed)
+
+        options = options or {}
+        requested_start = options.get("start_primitive")
+
+        if requested_start is not None:
+            if requested_start not in self._envs:
+                raise KeyError(f"Unknown reset primitive '{requested_start}'.")
+            next_active = requested_start
+            reset_reason = "explicit_option"
+        else:
+            next_active = self._resolve_reset_start()
+            reset_reason = "start_primitive" if next_active == self.config.start_primitive else "reset_primitive_fallback"
+
+        self._active_primitive = next_active
+        self._episode_step_count = 0
+
+        reset_info: dict[str, Any] = {
+            "active_primitive": self._active_primitive,
+            "reset_reason": reset_reason,
+            "requested_start": requested_start,
+        }
+
+        if seed is not None:
+            reset_info["seed"] = seed
+
+        obs = None
+        for name, env in self._envs.items():
+            env_seed = None if seed is None else seed + sum(ord(c) for c in name)
+            env_options = dict(options)
+            env_options["active_primitive"] = name
+            if name != self._active_primitive:
+                env_options["inactive_reset"] = True
+
+            if hasattr(env, "reset"):
+                env_obs, env_info = env.reset(seed=env_seed, options=env_options)
+            else:
+                env_obs, env_info = {}, {}
+
+            if name == self._active_primitive:
+                obs = env_obs
+                reset_info["primitive_reset_info"] = dict(env_info or {})
+
+        if obs is None:
+            raise RuntimeError(f"Failed to reset active primitive '{self._active_primitive}'.")
+
+        self._last_reset_info = reset_info
+        return obs, reset_info
 
     @staticmethod
     def _evaluate_transition(transition: Any, obs: dict[str, np.ndarray], info: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
@@ -57,6 +123,7 @@ class ManipulationPrimitiveNet(gym.Env):
             raise KeyError(f"Unknown active primitive '{active}'.")
 
         obs, reward, terminated, truncated, info = self._envs[active].step(action)
+        self._episode_step_count += 1
 
         transition_info = {
             "from": active,

--- a/tests/share/envs/test_manipulation_primitive_net_step.py
+++ b/tests/share/envs/test_manipulation_primitive_net_step.py
@@ -13,10 +13,15 @@ class DummyEnv:
         self.truncated = truncated
         self.info = info or {}
         self.last_action = None
+        self.reset_calls = []
 
     def step(self, action):
         self.last_action = action
         return self.obs, self.reward, self.terminated, self.truncated, dict(self.info)
+
+    def reset(self, *, seed=None, options=None):
+        self.reset_calls.append({"seed": seed, "options": dict(options or {})})
+        return self.obs, {"env": "dummy", "seed": seed}
 
 
 class StaticBoolTransition:
@@ -43,7 +48,9 @@ def _make_net(envs, transitions, active="pick"):
     net = ManipulationPrimitiveNet.__new__(ManipulationPrimitiveNet)
     net._envs = envs
     net._active_primitive = active
-    net.config = SimpleNamespace(transitions=transitions)
+    net.config = SimpleNamespace(transitions=transitions, start_primitive=active, reset_primitives=[])
+    net._episode_step_count = 0
+    net._last_reset_info = {}
     return net
 
 
@@ -106,3 +113,47 @@ def test_mp_net_step_applies_transition_reward_and_done_flags():
     assert info["transition"]["reason"] == "success"
     assert info["transition"]["transition_name"] == "success_edge"
     assert info["transition"]["transition_type"] == "threshold"
+
+
+def test_mp_net_reset_starts_from_start_primitive():
+    pick_env = DummyEnv(obs={"obs": np.array([1.0])})
+    place_env = DummyEnv(obs={"obs": np.array([2.0])})
+    net = _make_net(
+        envs={"pick": pick_env, "place": place_env},
+        transitions=[],
+        active="place",
+    )
+    net.config.start_primitive = "pick"
+    net.config.reset_primitives = ["reset"]
+    net._episode_step_count = 99
+
+    obs, info = net.reset(seed=7)
+
+    assert np.allclose(obs["obs"], np.array([1.0]))
+    assert net._active_primitive == "pick"
+    assert net._episode_step_count == 0
+    assert info["active_primitive"] == "pick"
+    assert info["reset_reason"] == "start_primitive"
+    assert len(pick_env.reset_calls) == 1
+    assert len(place_env.reset_calls) == 1
+
+
+def test_mp_net_reset_path_via_reset_primitives():
+    reset_env = DummyEnv(obs={"obs": np.array([9.0])})
+    place_env = DummyEnv(obs={"obs": np.array([2.0])})
+    net = _make_net(
+        envs={"reset": reset_env, "place": place_env},
+        transitions=[],
+        active="place",
+    )
+    net.config.start_primitive = "pick"
+    net.config.reset_primitives = ["reset", "alt_reset"]
+
+    obs, info = net.reset()
+
+    assert np.allclose(obs["obs"], np.array([9.0]))
+    assert net._active_primitive == "reset"
+    assert info["active_primitive"] == "reset"
+    assert info["reset_reason"] == "reset_primitive_fallback"
+    assert len(reset_env.reset_calls) == 1
+    assert len(place_env.reset_calls) == 1


### PR DESCRIPTION
### Motivation
- The MP-Net must provide clear, deterministic reset behavior across chained primitives so episodes start consistently and terminal/reset primitives can be supported as a runtime contract. 
- The issue board MPN-102 requires reset semantics that clear per-episode state, optionally route to configured reset primitives, and support runtime overrides.

### Description
- Add `reset_primitives: list[str]` to `ManipulationPrimitiveNetConfig` to allow explicit fallback reset routes via `src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py`.
- Introduce per-instance state fields `_last_reset_info` and `_episode_step_count`, and increment `_episode_step_count` each `step()` to keep lifecycle accounting consistent in `src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py`.
- Implement `_resolve_reset_start()` and a full `reset(seed=..., options=...)` that: resolves the next active primitive (prefers `start_primitive`, falls back to `reset_primitives`), supports `options['start_primitive']` override, clears episode state, fans out deterministic resets to all underlying primitive envs, and returns reset metadata in the info dict.
- Add unit tests to validate acceptance criteria and exercise the new behavior in `tests/share/envs/test_manipulation_primitive_net_step.py` (including `test_mp_net_reset_starts_from_start_primitive` and `test_mp_net_reset_path_via_reset_primitives`).

### Testing
- Ran `PYTHONPATH=src pytest -q tests/share/envs/test_manipulation_primitive_net_step.py` and all tests in that file succeeded (`5 passed`).
- The new tests exercise reset routing, per-env reset fanout, and episode state clearing and verified the expected reset metadata and step counter behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e5acc878832093686c6023a27d21)