### PR TITLE
Implement typed transition dataclasses for MP-Net (MPN-201)

### DIFF
--- a/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict, is_dataclass
 from typing import TYPE_CHECKING, Any
 
 import gymnasium as gym
@@ -114,6 +115,9 @@ class ManipulationPrimitiveNet(gym.Env):
             return condition, metadata or {}
         if isinstance(result, dict):
             return bool(result.get("condition_fulfilled", result.get("triggered", False))), result
+        if is_dataclass(result):
+            metadata = asdict(result)
+            return bool(metadata.get("condition_fulfilled", metadata.get("triggered", False))), metadata
 
         raise TypeError(f"Unsupported transition evaluation output type: {type(result)!r}")
 
@@ -124,6 +128,9 @@ class ManipulationPrimitiveNet(gym.Env):
 
         obs, reward, terminated, truncated, info = self._envs[active].step(action)
         self._episode_step_count += 1
+
+        info = dict(info)
+        info.setdefault("episode_step_count", self._episode_step_count)
 
         transition_info = {
             "from": active,
@@ -157,7 +164,6 @@ class ManipulationPrimitiveNet(gym.Env):
             self._active_primitive = transition_target
             break
 
-        info = dict(info)
         info["transition"] = transition_info
         info["active_primitive"] = self._active_primitive
 

--- a/src/share/envs/manipulation_primitive_net/transitions.py
+++ b/src/share/envs/manipulation_primitive_net/transitions.py
@@ -1,8 +1,144 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+import numpy as np
 
 from draccus import ChoiceRegistry
 
+
+@dataclass
+class TransitionOutcome:
+    condition_fulfilled: bool
+    next_primitive: str | None = None
+    additional_reward: float = 0.0
+    terminated: bool = False
+    truncated: bool = False
+    reason: str | None = None
+    transition_name: str | None = None
+    transition_type: str | None = None
+
+    def to_metadata(self) -> dict[str, Any]:
+        return asdict(self)
+
+
 @dataclass
 class MP_Transition(ChoiceRegistry):
-    def check(self, obs: dict, info: dict) -> bool:
+    next_primitive: str | None = None
+    additional_reward: float = 0.0
+    terminated: bool = False
+    truncated: bool = False
+    reason: str | None = None
+
+    def evaluate(self, obs: dict[str, Any], info: dict[str, Any]) -> TransitionOutcome:
         raise NotImplementedError
+
+    def check(self, obs: dict, info: dict) -> bool:
+        return self.evaluate(obs=obs, info=info).condition_fulfilled
+
+
+def _resolve_value(source: dict[str, Any], key: str) -> Any:
+    current: Any = source
+    for piece in key.split("."):
+        if not isinstance(current, dict) or piece not in current:
+            raise KeyError(f"Key '{key}' not found in transition source.")
+        current = current[piece]
+    return current
+
+
+def _to_scalar(value: Any) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    arr = np.asarray(value)
+    if arr.size != 1:
+        raise ValueError(f"Expected scalar-like value for transition comparison, received shape {arr.shape}.")
+    return float(arr.reshape(-1)[0])
+
+
+def _compare(lhs: float, rhs: float, operator: str) -> bool:
+    if operator == "ge":
+        return lhs >= rhs
+    if operator == "gt":
+        return lhs > rhs
+    if operator == "le":
+        return lhs <= rhs
+    if operator == "lt":
+        return lhs < rhs
+    if operator == "eq":
+        return lhs == rhs
+    if operator == "ne":
+        return lhs != rhs
+    raise ValueError(f"Unsupported comparison operator '{operator}'.")
+
+
+@MP_Transition.register_subclass("observation_threshold")
+@dataclass
+class ObservationThresholdTransition(MP_Transition):
+    obs_key: str = ""
+    threshold: float = 0.0
+    operator: Literal["ge", "gt", "le", "lt", "eq", "ne"] = "ge"
+
+    def evaluate(self, obs: dict[str, Any], info: dict[str, Any]) -> TransitionOutcome:
+        value = _to_scalar(_resolve_value(obs, self.obs_key))
+        fired = _compare(value, self.threshold, self.operator)
+        return TransitionOutcome(
+            condition_fulfilled=fired,
+            next_primitive=self.next_primitive,
+            additional_reward=self.additional_reward,
+            terminated=self.terminated,
+            truncated=self.truncated,
+            reason=self.reason or "observation_threshold",
+            transition_name=self.__class__.__name__,
+            transition_type="observation_threshold",
+        )
+
+
+@MP_Transition.register_subclass("time_limit")
+@dataclass
+class TimeLimitTransition(MP_Transition):
+    max_steps: int = 0
+    step_key: str = "episode_step_count"
+    terminated: bool = False
+    truncated: bool = True
+
+    def evaluate(self, obs: dict[str, Any], info: dict[str, Any]) -> TransitionOutcome:
+        current_steps = int(_to_scalar(_resolve_value(info, self.step_key)))
+        fired = current_steps >= self.max_steps
+        return TransitionOutcome(
+            condition_fulfilled=fired,
+            next_primitive=self.next_primitive,
+            additional_reward=self.additional_reward,
+            terminated=self.terminated,
+            truncated=self.truncated,
+            reason=self.reason or "time_limit",
+            transition_name=self.__class__.__name__,
+            transition_type="time_limit",
+        )
+
+
+@MP_Transition.register_subclass("reward_classifier")
+@dataclass
+class RewardClassifierTransition(MP_Transition):
+    metric_key: str = "success"
+    threshold: float = 0.5
+    operator: Literal["ge", "gt", "le", "lt", "eq", "ne"] = "ge"
+    additional_reward: float = 1.0
+
+    def evaluate(self, obs: dict[str, Any], info: dict[str, Any]) -> TransitionOutcome:
+        if self.metric_key in info:
+            metric = _resolve_value(info, self.metric_key)
+        else:
+            metric = _resolve_value(obs, self.metric_key)
+
+        value = _to_scalar(metric)
+        fired = _compare(value, self.threshold, self.operator)
+        return TransitionOutcome(
+            condition_fulfilled=fired,
+            next_primitive=self.next_primitive,
+            additional_reward=self.additional_reward,
+            terminated=self.terminated,
+            truncated=self.truncated,
+            reason=self.reason or "reward_classifier",
+            transition_name=self.__class__.__name__,
+            transition_type="reward_classifier",
+        )

--- a/tests/share/envs/test_manipulation_primitive_net_transitions.py
+++ b/tests/share/envs/test_manipulation_primitive_net_transitions.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+from share.envs.manipulation_primitive_net.transitions import (
+    ObservationThresholdTransition,
+    RewardClassifierTransition,
+    TimeLimitTransition,
+)
+
+
+def test_transition_threshold_triggers_and_returns_next_primitive():
+    transition = ObservationThresholdTransition(
+        obs_key="metrics.height",
+        threshold=0.4,
+        operator="ge",
+        next_primitive="place",
+        additional_reward=0.25,
+        reason="height_reached",
+    )
+
+    outcome = transition.evaluate(obs={"metrics": {"height": np.array([0.6])}}, info={})
+
+    assert outcome.condition_fulfilled
+    assert outcome.next_primitive == "place"
+    assert outcome.additional_reward == 0.25
+    assert outcome.reason == "height_reached"
+    assert outcome.transition_type == "observation_threshold"
+
+
+def test_transition_time_limit_sets_truncation_style_flags():
+    transition = TimeLimitTransition(max_steps=3)
+
+    outcome = transition.evaluate(obs={}, info={"episode_step_count": 3})
+
+    assert outcome.condition_fulfilled
+    assert not outcome.terminated
+    assert outcome.truncated
+    assert outcome.transition_type == "time_limit"
+
+
+def test_transition_classifier_adds_sparse_success_reward():
+    transition = RewardClassifierTransition(
+        metric_key="success",
+        threshold=0.5,
+        operator="ge",
+        additional_reward=2.0,
+        next_primitive="done",
+        terminated=True,
+    )
+
+    outcome = transition.evaluate(obs={}, info={"success": 1.0})
+
+    assert outcome.condition_fulfilled
+    assert outcome.additional_reward == 2.0
+    assert outcome.next_primitive == "done"
+    assert outcome.terminated
+    assert outcome.transition_type == "reward_classifier"


### PR DESCRIPTION
### Motivation
- The existing `MP_Transition` was a bare boolean-check interface and could not express rich outcomes such as next primitive, reward shaping, or episode-end semantics required by the MP-Net orchestration. 
- MP-Net transition evaluation must support typed, draccus-selectable transitions and a consistent metadata contract so orchestration can apply rewards and done/truncation flags reliably.

### Description
- Introduce a typed `TransitionOutcome` dataclass and update `MP_Transition` to expose an `evaluate(obs, info) -> TransitionOutcome` API while preserving `check(...)` compatibility (file: `src/share/envs/manipulation_primitive_net/transitions.py`).
- Add helper utilities `_resolve_value`, `_to_scalar`, and `_compare` and implement three `ChoiceRegistry`-registered transition types: `observation_threshold`, `time_limit`, and `reward_classifier` (file: `src/share/envs/manipulation_primitive_net/transitions.py`).
- Extend `ManipulationPrimitiveNet._evaluate_transition` to accept dataclass results via `is_dataclass`/`asdict` and inject `episode_step_count` into per-step `info` so time-limit transitions can evaluate against runtime progress (file: `src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py`).
- Add focused unit tests covering threshold routing, truncation-style time-limit behavior, and classifier reward shaping semantics (file: `tests/share/envs/test_manipulation_primitive_net_transitions.py`).

### Testing
- Running `PYTHONPATH=src pytest -q tests/share/envs/test_manipulation_primitive_net_step.py tests/share/envs/test_manipulation_primitive_net_transitions.py` executed the updated suite and all tests passed (8 passed).
- An initial `pytest` invocation without `PYTHONPATH` failed due to the test environment not having the `lerobot` package on `PYTHONPATH`, which is an environment setup issue rather than a code regression.
- Code was byte-checked via `PYTHONPATH=src python -m compileall src/share/envs/manipulation_primitive_net tests/share/envs/test_manipulation_primitive_net_transitions.py` and compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e75fd1e48320861d5688477ebde5)