### PR TITLE
Fix MP-Net reset routing and validate transition graph (terminal->reset rule)

### DIFF
--- a/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
@@ -6,6 +6,7 @@ from lerobot.envs import EnvConfig
 from lerobot.cameras import CameraConfig
 from lerobot.teleoperators import TeleoperatorConfig
 from lerobot.robots import RobotConfig
+from lerobot.utils.constants import DEFAULT_ROBOT_NAME
 
 from .transitions import MP_Transition
 from ..manipulation_primitive.config_manipulation_primitive import ManipulationPrimitiveConfig
@@ -27,6 +28,29 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
         # Handle multi robot configuration
         self.robot = self.robot if isinstance(self.robot, dict) else {DEFAULT_ROBOT_NAME: self.robot}
         self.teleop = self.teleop if isinstance(self.teleop, dict) else {DEFAULT_ROBOT_NAME: self.teleop}
-        for name in self.robot:
-            self.robot[name].cameras = {}
+        for name, robot_cfg in self.robot.items():
+            if robot_cfg is not None:
+                robot_cfg.cameras = {}
 
+        primitive_names = set(self.primitives)
+        if self.start_primitive not in primitive_names:
+            raise ValueError(f"start_primitive '{self.start_primitive}' is not present in primitives.")
+
+        reset_primitive_set = set(self.reset_primitives)
+        unknown_reset_primitives = reset_primitive_set - primitive_names
+        if unknown_reset_primitives:
+            unknown = ", ".join(sorted(unknown_reset_primitives))
+            raise ValueError(f"reset_primitives contain unknown primitive(s): {unknown}")
+
+        for source, target, _ in self.transitions:
+            if source not in primitive_names:
+                raise ValueError(f"Transition source '{source}' is not present in primitives.")
+            if target not in primitive_names:
+                raise ValueError(f"Transition target '{target}' is not present in primitives.")
+
+            source_config = self.primitives[source]
+            if getattr(source_config, "is_terminal_primitive", False) and target not in reset_primitive_set:
+                raise ValueError(
+                    "Terminal primitive transitions must target a reset primitive. "
+                    f"Invalid edge: {source} -> {target}."
+                )

--- a/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
@@ -33,14 +33,68 @@ class ManipulationPrimitiveNet(gym.Env):
         self._last_reset_info: dict[str, Any] = {}
         self._episode_step_count = 0
 
+    @staticmethod
+    def _default_action_for_env(env: Any) -> Any:
+        action_space = getattr(env, "action_space", None)
+        if action_space is not None and hasattr(action_space, "sample"):
+            sampled_action = action_space.sample()
+            if isinstance(sampled_action, np.ndarray):
+                return np.zeros_like(sampled_action)
+            return sampled_action
+        return np.zeros((1,), dtype=np.float32)
+
+    def _step_reset_path_until_start(
+        self,
+        obs: dict[str, np.ndarray],
+        info: dict[str, Any],
+        *,
+        max_steps: int,
+    ) -> tuple[dict[str, np.ndarray], dict[str, Any], int]:
+        reset_steps = 0
+
+        while self._active_primitive != self.config.start_primitive:
+            if reset_steps >= max_steps:
+                raise RuntimeError(
+                    "Exceeded maximum reset transition steps while routing to start primitive. "
+                    f"Active='{self._active_primitive}', start='{self.config.start_primitive}'."
+                )
+
+            transitioned = False
+            for source, default_target, transition in self.config.transitions:
+                if source != self._active_primitive:
+                    continue
+
+                fired, transition_metadata = self._evaluate_transition(transition=transition, obs=obs, info=info)
+                if not fired:
+                    continue
+
+                self._active_primitive = transition_metadata.get("next_primitive", default_target)
+                transitioned = True
+                break
+
+            if not transitioned:
+                raise RuntimeError(
+                    "Failed to route reset path to start primitive: no transition fired from "
+                    f"primitive '{self._active_primitive}'."
+                )
+
+            if self._active_primitive != self.config.start_primitive:
+                action = self._default_action_for_env(self._envs[self._active_primitive])
+                obs, _, _, _, info = self._envs[self._active_primitive].step(action)
+                info = dict(info or {})
+            reset_steps += 1
+
+        return obs, info, reset_steps
+
 
     def _resolve_reset_start(self) -> str:
-        if self.config.start_primitive in self._envs:
-            return self.config.start_primitive
-
-        for reset_primitive in getattr(self.config, "reset_primitives", []):
+        configured_reset_primitives = getattr(self.config, "reset_primitives", [])
+        for reset_primitive in configured_reset_primitives:
             if reset_primitive in self._envs:
                 return reset_primitive
+
+        if self.config.start_primitive in self._envs:
+            return self.config.start_primitive
 
         raise KeyError(
             f"Unable to resolve reset start primitive: start_primitive='{self.config.start_primitive}' "
@@ -93,6 +147,19 @@ class ManipulationPrimitiveNet(gym.Env):
 
         if obs is None:
             raise RuntimeError(f"Failed to reset active primitive '{self._active_primitive}'.")
+
+        reset_steps = 0
+        if self._active_primitive != self.config.start_primitive:
+            max_steps = max(1, len(self.config.transitions) + len(self._envs))
+            primitive_reset_info = dict(reset_info.get("primitive_reset_info") or {})
+            obs, primitive_reset_info, reset_steps = self._step_reset_path_until_start(
+                obs=obs,
+                info=primitive_reset_info,
+                max_steps=max_steps,
+            )
+            reset_info["primitive_reset_info"] = primitive_reset_info
+            reset_info["active_primitive"] = self._active_primitive
+            reset_info["reset_transition_steps"] = reset_steps
 
         self._last_reset_info = reset_info
         return obs, reset_info
@@ -194,7 +261,5 @@ class ManipulationPrimitiveNet(gym.Env):
             cameras[name].connect()
 
         return robot_dict, teleop_dict, cameras
-
-
 
 

--- a/tests/share/envs/test_manipulation_primitive_net_config.py
+++ b/tests/share/envs/test_manipulation_primitive_net_config.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import pytest
+
+from share.envs.manipulation_primitive_net.config_manipulation_primitive_net import (
+    ManipulationPrimitiveNetConfig,
+)
+from share.envs.manipulation_primitive_net.transitions import ObservationThresholdTransition
+
+
+def _transition():
+    return ObservationThresholdTransition(obs_key="x", threshold=0.0)
+
+
+def test_mp_net_config_rejects_unknown_primitive_in_transition():
+    with pytest.raises(ValueError, match="Transition target 'unknown'"):
+        ManipulationPrimitiveNetConfig(
+            start_primitive="pick",
+            primitives={"pick": SimpleNamespace(), "reset": SimpleNamespace()},
+            transitions=[("pick", "unknown", _transition())],
+            reset_primitives=["reset"],
+        )
+
+
+def test_mp_net_config_rejects_missing_start_primitive():
+    with pytest.raises(ValueError, match="start_primitive 'pick'"):
+        ManipulationPrimitiveNetConfig(
+            start_primitive="pick",
+            primitives={"reset": SimpleNamespace()},
+            transitions=[],
+            reset_primitives=["reset"],
+        )
+
+
+def test_mp_net_config_rejects_terminal_transition_to_non_reset_primitive():
+    with pytest.raises(ValueError, match="Terminal primitive transitions must target a reset primitive"):
+        ManipulationPrimitiveNetConfig(
+            start_primitive="pick",
+            primitives={
+                "pick": SimpleNamespace(),
+                "terminal": SimpleNamespace(is_terminal_primitive=True),
+                "reset": SimpleNamespace(),
+            },
+            transitions=[("terminal", "pick", _transition())],
+            reset_primitives=["reset"],
+        )
+
+
+def test_mp_net_config_allows_terminal_transition_to_reset_primitive():
+    config = ManipulationPrimitiveNetConfig(
+        start_primitive="pick",
+        primitives={
+            "pick": SimpleNamespace(),
+            "terminal": SimpleNamespace(is_terminal_primitive=True),
+            "reset": SimpleNamespace(),
+        },
+        transitions=[("terminal", "reset", _transition())],
+        reset_primitives=["reset"],
+    )
+
+    assert config.start_primitive == "pick"

--- a/tests/share/envs/test_manipulation_primitive_net_step.py
+++ b/tests/share/envs/test_manipulation_primitive_net_step.py
@@ -32,6 +32,17 @@ class StaticBoolTransition:
         return self.should_fire
 
 
+class SequencedTransition:
+    def __init__(self, outcomes):
+        self._outcomes = list(outcomes)
+
+    def evaluate(self, obs, info):
+        if self._outcomes:
+            fired, metadata = self._outcomes.pop(0)
+            return fired, metadata
+        return False, {}
+
+
 class RichTransition:
     def evaluate(self, obs, info):
         return True, {
@@ -140,10 +151,11 @@ def test_mp_net_reset_starts_from_start_primitive():
 
 def test_mp_net_reset_path_via_reset_primitives():
     reset_env = DummyEnv(obs={"obs": np.array([9.0])})
+    pick_env = DummyEnv(obs={"obs": np.array([3.0])})
     place_env = DummyEnv(obs={"obs": np.array([2.0])})
     net = _make_net(
-        envs={"reset": reset_env, "place": place_env},
-        transitions=[],
+        envs={"reset": reset_env, "pick": pick_env, "place": place_env},
+        transitions=[("reset", "pick", StaticBoolTransition(True))],
         active="place",
     )
     net.config.start_primitive = "pick"
@@ -152,8 +164,34 @@ def test_mp_net_reset_path_via_reset_primitives():
     obs, info = net.reset()
 
     assert np.allclose(obs["obs"], np.array([9.0]))
-    assert net._active_primitive == "reset"
-    assert info["active_primitive"] == "reset"
+    assert net._active_primitive == "pick"
+    assert info["active_primitive"] == "pick"
     assert info["reset_reason"] == "reset_primitive_fallback"
+    assert info["reset_transition_steps"] == 1
     assert len(reset_env.reset_calls) == 1
+    assert len(pick_env.reset_calls) == 1
     assert len(place_env.reset_calls) == 1
+
+
+def test_mp_net_reset_path_steps_intermediate_primitives_until_start():
+    reset_env = DummyEnv(obs={"obs": np.array([9.0])})
+    stage_env = DummyEnv(obs={"obs": np.array([7.0])})
+    start_env = DummyEnv(obs={"obs": np.array([5.0])})
+
+    net = _make_net(
+        envs={"reset": reset_env, "stage": stage_env, "start": start_env},
+        transitions=[
+            ("reset", "stage", SequencedTransition([(True, {})])),
+            ("stage", "start", SequencedTransition([(True, {})])),
+        ],
+        active="stage",
+    )
+    net.config.start_primitive = "start"
+    net.config.reset_primitives = ["reset"]
+
+    _, info = net.reset()
+
+    assert net._active_primitive == "start"
+    assert info["active_primitive"] == "start"
+    assert info["reset_transition_steps"] == 2
+    assert stage_env.last_action is not None


### PR DESCRIPTION
### Motivation
- The manipulation-primitive net reset behavior did not reliably route through configured reset primitives to reach the configured start primitive, and the transition graph lacked validation for invalid references and terminal-primitive outgoing edges.
- Transitions starting at terminal primitives must only target reset primitives to keep reset semantics well-defined and avoid runtime dead-ends.

### Description
- Add validation to `ManipulationPrimitiveNetConfig.__post_init__` to import and use `DEFAULT_ROBOT_NAME`, ensure `start_primitive` exists, ensure all `reset_primitives` exist, ensure every transition source/target references known primitives, and enforce that transitions from primitives marked `is_terminal_primitive=True` only target configured reset primitives (file: `src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py`).
- Implement reset-path routing in `ManipulationPrimitiveNet.reset` by preferring configured reset primitives, then stepping transitions (via a new helper `_step_reset_path_until_start`) until the configured `start_primitive` is reached; add `_default_action_for_env` to generate safe no-op actions for intermediate env steps and include `reset_transition_steps` diagnostic in the returned reset info (file: `src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py`).
- Adjust `_resolve_reset_start` so configured reset primitives are preferred when available, falling back to `start_primitive` if present in `_envs`.
- Add and update unit tests to cover reset-path traversal and config validation: extend `tests/share/envs/test_manipulation_primitive_net_step.py` with multi-hop reset scenarios and add `tests/share/envs/test_manipulation_primitive_net_config.py` to assert invalid/valid graph validation cases.

### Testing
- Ran the MP-Net step/reset tests with `PYTHONPATH=src pytest -q tests/share/envs/test_manipulation_primitive_net_step.py` and all tests passed (6 passed). 
- Attempted to run the new config tests with `PYTHONPATH=src pytest -q tests/share/envs/test_manipulation_primitive_net_config.py`, but collection failed in this container due to a missing optional system dependency (`atomics`), so those tests could not be executed here (the failures are due to the environment, not assertions in the new tests).
- Added tests: `test_mp_net_reset_path_via_reset_primitives`, `test_mp_net_reset_path_steps_intermediate_primitives_until_start`, and config validation tests `test_mp_net_config_rejects_unknown_primitive_in_transition`, `test_mp_net_config_rejects_missing_start_primitive`, `test_mp_net_config_rejects_terminal_transition_to_non_reset_primitive`, and `test_mp_net_config_allows_terminal_transition_to_reset_primitive`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e922f174832094193303dcc6ee5e)