### PR TITLE
MPN-202: Add transition graph validation for ManipulationPrimitiveNet

### DIFF
--- a/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
@@ -42,15 +42,71 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
             unknown = ", ".join(sorted(unknown_reset_primitives))
             raise ValueError(f"reset_primitives contain unknown primitive(s): {unknown}")
 
-        for source, target, _ in self.transitions:
+        outgoing_edges: dict[str, set[str]] = {name: set() for name in primitive_names}
+
+        for source, target, transition in self.transitions:
             if source not in primitive_names:
                 raise ValueError(f"Transition source '{source}' is not present in primitives.")
             if target not in primitive_names:
                 raise ValueError(f"Transition target '{target}' is not present in primitives.")
 
+            resolved_target = target
+            transition_target = getattr(transition, "next_primitive", None)
+            if transition_target is not None:
+                if transition_target not in primitive_names:
+                    raise ValueError(
+                        "Transition resolver points to unknown primitive "
+                        f"'{transition_target}' from source '{source}'."
+                    )
+                resolved_target = transition_target
+
+            outgoing_edges[source].add(resolved_target)
+
             source_config = self.primitives[source]
-            if getattr(source_config, "is_terminal_primitive", False) and target not in reset_primitive_set:
+            if getattr(source_config, "is_terminal_primitive", False) and resolved_target not in reset_primitive_set:
                 raise ValueError(
                     "Terminal primitive transitions must target a reset primitive. "
-                    f"Invalid edge: {source} -> {target}."
+                    f"Invalid edge: {source} -> {resolved_target}."
                 )
+
+        def _reachable_from(start: str) -> set[str]:
+            visited = {start}
+            frontier = [start]
+
+            while frontier:
+                node = frontier.pop()
+                for nxt in outgoing_edges[node]:
+                    if nxt in visited:
+                        continue
+                    visited.add(nxt)
+                    frontier.append(nxt)
+
+            return visited
+
+        for primitive_name, primitive_cfg in self.primitives.items():
+            is_terminal = bool(getattr(primitive_cfg, "is_terminal_primitive", False))
+            if not is_terminal and not outgoing_edges[primitive_name]:
+                raise ValueError(
+                    "Detected non-terminal dead-end primitive without outgoing transitions: "
+                    f"'{primitive_name}'. Mark it terminal or add an outgoing transition."
+                )
+
+        reachable_from_start = _reachable_from(self.start_primitive)
+        unreachable_terminals = sorted(
+            name
+            for name, primitive_cfg in self.primitives.items()
+            if bool(getattr(primitive_cfg, "is_terminal_primitive", False)) and name not in reachable_from_start
+        )
+        if unreachable_terminals:
+            raise ValueError(
+                "Terminal primitive(s) are unreachable from start_primitive "
+                f"'{self.start_primitive}': {', '.join(unreachable_terminals)}"
+            )
+
+        if reset_primitive_set:
+            for reset_name in sorted(reset_primitive_set):
+                if self.start_primitive not in _reachable_from(reset_name):
+                    raise ValueError(
+                        "Reset primitive has no transition path to start_primitive: "
+                        f"'{reset_name}' -> '{self.start_primitive}'."
+                    )

--- a/tests/share/envs/test_manipulation_primitive_net_config.py
+++ b/tests/share/envs/test_manipulation_primitive_net_config.py
@@ -8,8 +8,8 @@ from share.envs.manipulation_primitive_net.config_manipulation_primitive_net imp
 from share.envs.manipulation_primitive_net.transitions import ObservationThresholdTransition
 
 
-def _transition():
-    return ObservationThresholdTransition(obs_key="x", threshold=0.0)
+def _transition(*, next_primitive=None):
+    return ObservationThresholdTransition(obs_key="x", threshold=0.0, next_primitive=next_primitive)
 
 
 def test_mp_net_config_rejects_unknown_primitive_in_transition():
@@ -54,7 +54,101 @@ def test_mp_net_config_allows_terminal_transition_to_reset_primitive():
             "terminal": SimpleNamespace(is_terminal_primitive=True),
             "reset": SimpleNamespace(),
         },
-        transitions=[("terminal", "reset", _transition())],
+        transitions=[("pick", "terminal", _transition()), ("terminal", "reset", _transition())],
+        reset_primitives=["reset"],
+    )
+
+    assert config.start_primitive == "pick"
+
+
+def test_mp_net_config_rejects_non_terminal_dead_end():
+    with pytest.raises(ValueError, match="non-terminal dead-end primitive"):
+        ManipulationPrimitiveNetConfig(
+            start_primitive="pick",
+            primitives={
+                "pick": SimpleNamespace(),
+                "place": SimpleNamespace(),
+                "terminal": SimpleNamespace(is_terminal_primitive=True),
+                "reset": SimpleNamespace(),
+            },
+            transitions=[
+                ("pick", "terminal", _transition()),
+                ("terminal", "reset", _transition()),
+                ("reset", "pick", _transition()),
+            ],
+            reset_primitives=["reset"],
+        )
+
+
+def test_mp_net_config_rejects_unreachable_terminal():
+    with pytest.raises(ValueError, match="unreachable from start_primitive"):
+        ManipulationPrimitiveNetConfig(
+            start_primitive="pick",
+            primitives={
+                "pick": SimpleNamespace(),
+                "place": SimpleNamespace(),
+                "terminal": SimpleNamespace(is_terminal_primitive=True),
+                "reset": SimpleNamespace(),
+            },
+            transitions=[
+                ("pick", "place", _transition()),
+                ("place", "pick", _transition()),
+                ("terminal", "reset", _transition()),
+                ("reset", "pick", _transition()),
+            ],
+            reset_primitives=["reset"],
+        )
+
+
+def test_mp_net_config_rejects_reset_without_path_to_start():
+    with pytest.raises(ValueError, match="Reset primitive has no transition path to start_primitive"):
+        ManipulationPrimitiveNetConfig(
+            start_primitive="pick",
+            primitives={
+                "pick": SimpleNamespace(),
+                "terminal": SimpleNamespace(is_terminal_primitive=True),
+                "reset": SimpleNamespace(),
+            },
+            transitions=[
+                ("pick", "terminal", _transition()),
+                ("terminal", "reset", _transition()),
+                ("reset", "terminal", _transition()),
+            ],
+            reset_primitives=["reset"],
+        )
+
+
+def test_mp_net_config_rejects_unknown_next_primitive_override():
+    with pytest.raises(ValueError, match="Transition resolver points to unknown primitive"):
+        ManipulationPrimitiveNetConfig(
+            start_primitive="pick",
+            primitives={
+                "pick": SimpleNamespace(),
+                "terminal": SimpleNamespace(is_terminal_primitive=True),
+                "reset": SimpleNamespace(),
+            },
+            transitions=[
+                ("pick", "terminal", _transition(next_primitive="terminal")),
+                ("terminal", "reset", _transition(next_primitive="bogus")),
+                ("reset", "pick", _transition(next_primitive="pick")),
+            ],
+            reset_primitives=["reset"],
+        )
+
+
+def test_mp_net_config_allows_intentional_terminal_dead_end():
+    config = ManipulationPrimitiveNetConfig(
+        start_primitive="pick",
+        primitives={
+            "pick": SimpleNamespace(),
+            "terminal": SimpleNamespace(is_terminal_primitive=True),
+            "reset": SimpleNamespace(),
+        },
+        transitions=[
+            ("pick", "terminal", _transition()),
+            ("terminal", "reset", _transition()),
+            ("reset", "pick", _transition()),
+        ],
         reset_primitives=["reset"],
     )
 


### PR DESCRIPTION
### Motivation
- Prevent runtime failures from misconfigured MP-Net graphs by validating transition references and graph topology at config load time.
- Detect common authoring errors early such as unknown `next_primitive` overrides, non-terminal dead-ends, unreachable terminal nodes, and reset primitives that cannot route back to the `start_primitive`.

### Description
- Added outgoing-edge graph construction and resolution of dynamic transition targets in `ManipulationPrimitiveNetConfig.__post_init__` (file `src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py`).
- Validate `transition.next_primitive` override targets against known primitives and surface actionable `ValueError`s for unknown references.
- Enforce that terminal primitives only point to configured reset primitives after resolving transition targets, and detect non-terminal dead-end primitives with no outgoing edges.
- Add reachability checks that ensure terminal primitives are reachable from `start_primitive` and that each configured reset primitive can route back to `start_primitive`.
- Expanded `tests/share/envs/test_manipulation_primitive_net_config.py` to cover the new validation cases (unknown targets, non-terminal dead-ends, unreachable terminals, reset routing, and valid terminal dead-end scenarios).

### Testing
- Ran full pytest command `pytest -q tests/share/envs/test_manipulation_primitive_net_config.py tests/share/envs/test_manipulation_primitive_net_transitions.py tests/share/envs/test_manipulation_primitive_net_step.py`, which failed in this environment due to `ModuleNotFoundError: No module named 'lerobot'` during test collection.
- Ran `PYTHONPATH=src pytest -q tests/share/envs/test_manipulation_primitive_net_config.py`, which failed in this environment due to a missing optional dependency `atomics` in the import chain.
- Ran `python -m compileall` on the modified config and test files, which completed successfully.

Note: The new validation and tests are self-contained and expected to pass in CI where project dependencies are available; local failures above are due to the restricted test environment lacking project dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2eae8bbcc8320b93008f42f2eb56c)