### PR TITLE
MPN-301: Add terminal/reset primitive metadata and enforce lifecycle semantics

### DIFF
--- a/src/share/envs/AGENTS.md
+++ b/src/share/envs/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent notes for `src/share/envs`
+
+- Keep docstrings brief and accurate in every file touched for env/MP-Net work.
+- When adding or changing primitive lifecycle behavior, update docstrings in config and runtime modules in the same patch.

--- a/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
+++ b/src/share/envs/manipulation_primitive/config_manipulation_primitive.py
@@ -138,9 +138,11 @@ class ManipulationPrimitiveProcessorConfig:
 
 @dataclass
 class ManipulationPrimitiveConfig(EnvConfig):
-    """Configuration for the HILSerlRobotEnv environment."""
+    """Configuration for one manipulation primitive in a primitive net."""
     task_frame: dict[str, TaskFrame] = field(default_factory=dict)
     processor: ManipulationPrimitiveProcessorConfig = field(default_factory=ManipulationPrimitiveProcessorConfig)
+    is_terminal_primitive: bool = False
+    is_reset_primitive: bool = False
 
     _kinematics_solver: dict = field(default_factory=dict)
     _joint_names: dict = field(default_factory=dict)
@@ -457,5 +459,4 @@ class ManipulationPrimitiveConfig(EnvConfig):
             if ft.type == FeatureType.VISUAL:
                 key = strip_prefix(key, PREFIXES_TO_STRIP)
                 self.features[f"{OBS_IMAGES}.{key}"] = PolicyFeature(type=FeatureType.VISUAL, shape=ft.shape)
-
 

--- a/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
@@ -14,6 +14,8 @@ from ..manipulation_primitive.config_manipulation_primitive import ManipulationP
 
 @dataclass
 class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
+    """Serializable config for chaining manipulation primitives with transitions."""
+
     start_primitive: str
     primitives: dict[str, ManipulationPrimitiveConfig]
     transitions: list[tuple[str, str, MP_Transition]]
@@ -25,6 +27,7 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
     cameras: dict[str, CameraConfig] = field(default_factory=dict)
 
     def __post_init__(self):
+        """Validate primitive roles and transition graph semantics for MP-Net."""
         # Handle multi robot configuration
         self.robot = self.robot if isinstance(self.robot, dict) else {DEFAULT_ROBOT_NAME: self.robot}
         self.teleop = self.teleop if isinstance(self.teleop, dict) else {DEFAULT_ROBOT_NAME: self.teleop}
@@ -36,7 +39,14 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
         if self.start_primitive not in primitive_names:
             raise ValueError(f"start_primitive '{self.start_primitive}' is not present in primitives.")
 
-        reset_primitive_set = set(self.reset_primitives)
+        metadata_reset_primitives = {
+            name
+            for name, primitive_cfg in self.primitives.items()
+            if bool(getattr(primitive_cfg, "is_reset_primitive", False))
+        }
+        reset_primitive_set = set(self.reset_primitives) | metadata_reset_primitives
+        self.reset_primitives = sorted(reset_primitive_set)
+
         unknown_reset_primitives = reset_primitive_set - primitive_names
         if unknown_reset_primitives:
             unknown = ", ".join(sorted(unknown_reset_primitives))
@@ -69,6 +79,12 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
                     f"Invalid edge: {source} -> {resolved_target}."
                 )
 
+            if bool(getattr(source_config, "is_reset_primitive", False)) and resolved_target not in primitive_names:
+                raise ValueError(
+                    "Reset primitive transition points to unknown primitive. "
+                    f"Invalid edge: {source} -> {resolved_target}."
+                )
+
         def _reachable_from(start: str) -> set[str]:
             visited = {start}
             frontier = [start]
@@ -82,6 +98,14 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
                     frontier.append(nxt)
 
             return visited
+
+        for reset_name in sorted(reset_primitive_set):
+            primitive_cfg = self.primitives[reset_name]
+            if not bool(getattr(primitive_cfg, "is_reset_primitive", False)):
+                raise ValueError(
+                    "reset_primitives entries must set is_reset_primitive=True. "
+                    f"Invalid primitive: '{reset_name}'."
+                )
 
         for primitive_name, primitive_cfg in self.primitives.items():
             is_terminal = bool(getattr(primitive_cfg, "is_terminal_primitive", False))

--- a/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 
 class ManipulationPrimitiveNet(gym.Env):
+    """Gym wrapper that chains manipulation primitives using typed transitions."""
+
     def __init__(self, config: "ManipulationPrimitiveNetConfig"):
 
         self.config = config
@@ -189,6 +191,7 @@ class ManipulationPrimitiveNet(gym.Env):
         raise TypeError(f"Unsupported transition evaluation output type: {type(result)!r}")
 
     def step(self, action: np.ndarray | torch.Tensor) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, Any]]:
+        """Step active primitive, then apply one matching transition if available."""
         active = self._active_primitive
         if active not in self._envs:
             raise KeyError(f"Unknown active primitive '{active}'.")
@@ -207,6 +210,7 @@ class ManipulationPrimitiveNet(gym.Env):
             "transition_type": None,
         }
 
+        transition_fired = False
         for source, default_target, transition in self.config.transitions:
             if source != active:
                 continue
@@ -215,6 +219,7 @@ class ManipulationPrimitiveNet(gym.Env):
             if not fired:
                 continue
 
+            transition_fired = True
             transition_target = transition_metadata.get("next_primitive", default_target)
             reward += float(transition_metadata.get("additional_reward", 0.0))
             terminated = bool(terminated or transition_metadata.get("terminated", False))
@@ -230,6 +235,16 @@ class ManipulationPrimitiveNet(gym.Env):
 
             self._active_primitive = transition_target
             break
+
+        if not transition_fired and bool(getattr(self.config.primitives.get(active), "is_terminal_primitive", False)):
+            terminated = True
+            transition_info = {
+                "from": active,
+                "to": active,
+                "reason": "terminal_primitive_no_transition",
+                "transition_name": None,
+                "transition_type": "terminal_policy",
+            }
 
         info["transition"] = transition_info
         info["active_primitive"] = self._active_primitive

--- a/tests/share/envs/test_manipulation_primitive_net_config.py
+++ b/tests/share/envs/test_manipulation_primitive_net_config.py
@@ -153,3 +153,40 @@ def test_mp_net_config_allows_intentional_terminal_dead_end():
     )
 
     assert config.start_primitive == "pick"
+
+
+def test_mp_net_config_collects_reset_primitives_from_metadata():
+    config = ManipulationPrimitiveNetConfig(
+        start_primitive="pick",
+        primitives={
+            "pick": SimpleNamespace(),
+            "terminal": SimpleNamespace(is_terminal_primitive=True),
+            "reset": SimpleNamespace(is_reset_primitive=True),
+        },
+        transitions=[
+            ("pick", "terminal", _transition()),
+            ("terminal", "reset", _transition()),
+            ("reset", "pick", _transition()),
+        ],
+        reset_primitives=[],
+    )
+
+    assert config.reset_primitives == ["reset"]
+
+
+def test_mp_net_config_rejects_reset_list_entry_without_metadata_flag():
+    with pytest.raises(ValueError, match="must set is_reset_primitive=True"):
+        ManipulationPrimitiveNetConfig(
+            start_primitive="pick",
+            primitives={
+                "pick": SimpleNamespace(),
+                "terminal": SimpleNamespace(is_terminal_primitive=True),
+                "reset": SimpleNamespace(),
+            },
+            transitions=[
+                ("pick", "terminal", _transition()),
+                ("terminal", "reset", _transition()),
+                ("reset", "pick", _transition()),
+            ],
+            reset_primitives=["reset"],
+        )

--- a/tests/share/envs/test_manipulation_primitive_net_step.py
+++ b/tests/share/envs/test_manipulation_primitive_net_step.py
@@ -55,11 +55,13 @@ class RichTransition:
         }
 
 
-def _make_net(envs, transitions, active="pick"):
+def _make_net(envs, transitions, active="pick", primitives=None):
     net = ManipulationPrimitiveNet.__new__(ManipulationPrimitiveNet)
     net._envs = envs
     net._active_primitive = active
-    net.config = SimpleNamespace(transitions=transitions, start_primitive=active, reset_primitives=[])
+    if primitives is None:
+        primitives = {name: SimpleNamespace() for name in envs}
+    net.config = SimpleNamespace(transitions=transitions, start_primitive=active, reset_primitives=[], primitives=primitives)
     net._episode_step_count = 0
     net._last_reset_info = {}
     return net
@@ -195,3 +197,59 @@ def test_mp_net_reset_path_steps_intermediate_primitives_until_start():
     assert info["active_primitive"] == "start"
     assert info["reset_transition_steps"] == 2
     assert stage_env.last_action is not None
+
+
+def test_terminal_primitive_ends_or_routes_based_on_transition():
+    terminal_env = DummyEnv(obs={"obs": np.array([1.0])}, reward=0.2)
+    reset_env = DummyEnv(obs={"obs": np.array([0.0])})
+
+    net_end = _make_net(
+        envs={"terminal": terminal_env, "reset": reset_env},
+        transitions=[],
+        active="terminal",
+        primitives={"terminal": SimpleNamespace(is_terminal_primitive=True), "reset": SimpleNamespace(is_reset_primitive=True)},
+    )
+
+    _, _, terminated, _, info = net_end.step(np.array([0.0]))
+    assert terminated
+    assert net_end._active_primitive == "terminal"
+    assert info["transition"]["reason"] == "terminal_primitive_no_transition"
+
+    net_route = _make_net(
+        envs={"terminal": terminal_env, "reset": reset_env},
+        transitions=[("terminal", "reset", StaticBoolTransition(True))],
+        active="terminal",
+        primitives={"terminal": SimpleNamespace(is_terminal_primitive=True), "reset": SimpleNamespace(is_reset_primitive=True)},
+    )
+
+    _, _, terminated, _, info = net_route.step(np.array([0.0]))
+    assert not terminated
+    assert net_route._active_primitive == "reset"
+    assert info["transition"]["to"] == "reset"
+
+
+def test_reset_primitive_routes_back_to_start_domain():
+    reset_env = DummyEnv(obs={"obs": np.array([9.0])})
+    stage_env = DummyEnv(obs={"obs": np.array([7.0])})
+    start_env = DummyEnv(obs={"obs": np.array([5.0])})
+
+    net = _make_net(
+        envs={"reset": reset_env, "stage": stage_env, "start": start_env},
+        transitions=[
+            ("reset", "stage", StaticBoolTransition(True)),
+            ("stage", "start", StaticBoolTransition(True)),
+        ],
+        active="start",
+        primitives={
+            "reset": SimpleNamespace(is_reset_primitive=True),
+            "stage": SimpleNamespace(),
+            "start": SimpleNamespace(),
+        },
+    )
+    net.config.start_primitive = "start"
+    net.config.reset_primitives = ["reset"]
+
+    _, info = net.reset()
+
+    assert net._active_primitive == "start"
+    assert info["reset_transition_steps"] == 2


### PR DESCRIPTION
### Motivation

- Primitive nets need explicit runtime and config-level support for terminal and reset primitive roles so episodes and reset paths behave deterministically. 
- The change implements the recommended design of representing lifecycle roles in primitive metadata and validating transition semantics at config-load time. 

### Description

- Added lifecycle metadata flags `is_terminal_primitive` and `is_reset_primitive` to `ManipulationPrimitiveConfig` and updated its docstring. 
- Extended `ManipulationPrimitiveNetConfig` validation to merge `reset_primitives` with metadata-discovered reset primitives, require listed reset primitives to have `is_reset_primitive=True`, and enforce that terminal primitives only transition to reset primitives. 
- Updated `ManipulationPrimitiveNet.step` to mark the episode as terminated and emit a clear transition diagnostic when a terminal primitive has no fired transition, while still allowing terminal→reset routing when a transition does fire. 
- Added unit tests exercising the new semantics and added a lightweight `src/share/envs/AGENTS.md` note reminding contributors to keep docstrings brief and update them when touching lifecycle logic. 

### Testing

- Ran static compilation of modified modules with `python -m py_compile ...` which completed successfully. 
- Attempted to run the focused unit tests with `PYTHONPATH=src pytest -q tests/share/envs/test_manipulation_primitive_net_config.py tests/share/envs/test_manipulation_primitive_net_step.py` but collection failed due to a missing optional runtime dependency `atomics` in the container. 
- The repository-level `pytest` run without `PYTHONPATH` initially failed during import resolution, so local full test execution requires the same runtime deps used by CI (installing `atomics`/project deps will allow the new tests to execute).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ed4bd0e08320b9439875792c9a2b)