### PR TITLE
Fix MP-Net config validation ordering and draccus decoding

### DIFF
--- a/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
@@ -14,7 +14,7 @@ from ..manipulation_primitive.config_manipulation_primitive import ManipulationP
 
 @EnvConfig.register_subclass(name="manipulation_primitive_net")
 @dataclass
-class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
+class ManipulationPrimitiveNetConfig:
     """Serializable config for chaining manipulation primitives with transitions."""
 
     start_primitive: str
@@ -100,17 +100,10 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
 
             return visited
 
-        for reset_name in sorted(reset_primitive_set):
-            primitive_cfg = self.primitives[reset_name]
-            if not bool(getattr(primitive_cfg, "is_reset_primitive", False)):
-                raise ValueError(
-                    "reset_primitives entries must set is_reset_primitive=True. "
-                    f"Invalid primitive: '{reset_name}'."
-                )
-
         for primitive_name, primitive_cfg in self.primitives.items():
             is_terminal = bool(getattr(primitive_cfg, "is_terminal_primitive", False))
-            if not is_terminal and not outgoing_edges[primitive_name]:
+            is_reset = primitive_name in reset_primitive_set
+            if not is_terminal and not is_reset and not outgoing_edges[primitive_name]:
                 raise ValueError(
                     "Detected non-terminal dead-end primitive without outgoing transitions: "
                     f"'{primitive_name}'. Mark it terminal or add an outgoing transition."
@@ -135,3 +128,11 @@ class ManipulationPrimitiveNetConfig(draccus.ChoiceRegistry):
                         "Reset primitive has no transition path to start_primitive: "
                         f"'{reset_name}' -> '{self.start_primitive}'."
                     )
+
+        for reset_name in sorted(reset_primitive_set):
+            primitive_cfg = self.primitives[reset_name]
+            if not bool(getattr(primitive_cfg, "is_reset_primitive", False)):
+                raise ValueError(
+                    "reset_primitives entries must set is_reset_primitive=True. "
+                    f"Invalid primitive: '{reset_name}'."
+                )


### PR DESCRIPTION
### Motivation
- `draccus.decode`/`draccus.load` should be able to parse MP-Net config dicts without requiring a top-level `type` key so typed YAML/dict configs used in tests decode correctly.  
- Graph-structure validation should report non-terminal dead-end/unreachable errors before strict metadata checks on reset entries to match test expectations.  
- Reset primitives must be exempt from the non-terminal dead-end check so a reset node without outgoing edges is not incorrectly flagged.

### Description
- Remove `draccus.ChoiceRegistry` inheritance from `ManipulationPrimitiveNetConfig` so `draccus.decode`/`draccus.load` can parse plain config dictionaries without a `type` key.  
- Update dead-end detection to treat reset primitives (entries in `reset_primitives` or primitives with `is_reset_primitive=True`) as exempt from the non-terminal dead-end check.  
- Move the strict enforcement that every name in `reset_primitives` must set `is_reset_primitive=True` to the end of the validation sequence so structural graph errors surface first.  
- Changes applied in `src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py`.

### Testing
- Ran `pytest -q` which failed to collect due to environment/import path issues and missing third-party packages so the full suite could not be executed.  
- Ran `PYTHONPATH=src pytest -q` which also failed during collection because of missing native deps such as `atomics` and `matplotlib`.  
- Ran `PYTHONPATH=src pytest -q tests/share/envs/test_manipulation_primitive_net_config.py` which could not complete collection due to the `atomics` import pulled in through the environment config chain.  
- Attempted `python -m pip install atomics matplotlib pytest-timeout` to satisfy test deps but installation was blocked by network/proxy restrictions in the current environment, so automated validation could not finish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f249bc148320b5259fec6be9a5e0)