### PR TITLE
Implement MP-Net reset/done API contract semantics for EPIC MPN-C

### DIFF
--- a/src/share/envs/ISSUE_BOARD_Manipulation_Primitive_Net.md
+++ b/src/share/envs/ISSUE_BOARD_Manipulation_Primitive_Net.md
@@ -236,7 +236,7 @@ This contract is mandatory for any future refactor of `ManipulationPrimitiveNet.
 
 ### MPN-301: Formalize terminal and reset primitive roles
 **Priority:** P1  
-**Status:** Todo  
+**Status:** Partially Done  
 **Owner:** Unassigned
 
 #### Problem
@@ -264,7 +264,25 @@ Keep a **single transition list** for simplicity and serializability. Differenti
 
 ---
 
+### MPN-302: Enforce MP-Net step/reset API contract in runtime info
+**Priority:** P0  
+**Status:** Partially Done  
+**Owner:** Unassigned
+
+#### Progress update
+- Gym-level done semantics now require reset-before-next-step once the MP-Net episode ends.
+- Primitive-level done flags are surfaced in `info` without ending the MP-Net episode by default.
+- Segment boundary markers are emitted in `info` for primitive switches (`segment_done`, `segment_from`, `segment_to`, `segment_reason`).
+
+#### Remaining
+- Add explicit segment-cut support when segment ends without primitive switch.
+- Expand transition diagnostics with stricter validation for missing `next_primitive` on fired transitions.
+
+---
+
 ## EPIC MPN-D — Config & Serialization (Draccus-First)
+
+> Backlog note: Serialization-focused work is intentionally deprioritized for now while EPIC MPN-C runtime semantics are finalized.
 
 ### MPN-401: Make MP-Net fully serializable with typed primitive dictionaries
 **Priority:** P0  

--- a/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/config_manipulation_primitive_net.py
@@ -15,7 +15,7 @@ from ..manipulation_primitive.config_manipulation_primitive import ManipulationP
 @EnvConfig.register_subclass(name="manipulation_primitive_net")
 @dataclass
 class ManipulationPrimitiveNetConfig:
-    """Serializable config for chaining manipulation primitives with transitions."""
+    """Serializable config for MP-Net transition routing and reset/start semantics."""
 
     start_primitive: str
     primitives: dict[str, ManipulationPrimitiveConfig]

--- a/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
+++ b/src/share/envs/manipulation_primitive_net/env_manipulation_primitive_net.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class ManipulationPrimitiveNet(gym.Env):
-    """Gym wrapper that chains manipulation primitives using typed transitions."""
+    """Gym env that composes manipulation primitives with explicit transitions."""
 
     def __init__(self, config: "ManipulationPrimitiveNetConfig"):
 
@@ -34,6 +34,7 @@ class ManipulationPrimitiveNet(gym.Env):
         self._active_primitive = self.config.start_primitive
         self._last_reset_info: dict[str, Any] = {}
         self._episode_step_count = 0
+        self._needs_reset = False
 
     @staticmethod
     def _default_action_for_env(env: Any) -> Any:
@@ -104,6 +105,7 @@ class ManipulationPrimitiveNet(gym.Env):
         )
 
     def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None) -> tuple[dict[str, np.ndarray], dict[str, Any]]:
+        """Reset all primitive envs and return an observation from the start primitive domain."""
         super().reset(seed=seed)
 
         options = options or {}
@@ -120,6 +122,7 @@ class ManipulationPrimitiveNet(gym.Env):
 
         self._active_primitive = next_active
         self._episode_step_count = 0
+        self._needs_reset = False
 
         reset_info: dict[str, Any] = {
             "active_primitive": self._active_primitive,
@@ -191,16 +194,30 @@ class ManipulationPrimitiveNet(gym.Env):
         raise TypeError(f"Unsupported transition evaluation output type: {type(result)!r}")
 
     def step(self, action: np.ndarray | torch.Tensor) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, Any]]:
-        """Step active primitive, then apply one matching transition if available."""
+        """Step active primitive once and evaluate at most one outgoing transition."""
+        if self._needs_reset:
+            raise RuntimeError("step() called after MP-Net episode finished; call reset() before stepping again.")
+
         active = self._active_primitive
         if active not in self._envs:
             raise KeyError(f"Unknown active primitive '{active}'.")
 
-        obs, reward, terminated, truncated, info = self._envs[active].step(action)
+        obs, reward, prim_terminated, prim_truncated, info = self._envs[active].step(action)
         self._episode_step_count += 1
 
-        info = dict(info)
+        info = dict(info or {})
         info.setdefault("episode_step_count", self._episode_step_count)
+        info["primitive_done"] = bool(prim_terminated or prim_truncated)
+        info["primitive_terminated"] = bool(prim_terminated)
+        info["primitive_truncated"] = bool(prim_truncated)
+        if "primitive_done_reason" not in info:
+            if prim_terminated:
+                info["primitive_done_reason"] = "primitive_terminated"
+            elif prim_truncated:
+                info["primitive_done_reason"] = "primitive_truncated"
+
+        terminated = False
+        truncated = False
 
         transition_info = {
             "from": active,
@@ -211,6 +228,7 @@ class ManipulationPrimitiveNet(gym.Env):
         }
 
         transition_fired = False
+        transition_additional_reward = 0.0
         for source, default_target, transition in self.config.transitions:
             if source != active:
                 continue
@@ -221,7 +239,8 @@ class ManipulationPrimitiveNet(gym.Env):
 
             transition_fired = True
             transition_target = transition_metadata.get("next_primitive", default_target)
-            reward += float(transition_metadata.get("additional_reward", 0.0))
+            transition_additional_reward = float(transition_metadata.get("additional_reward", 0.0))
+            reward += transition_additional_reward
             terminated = bool(terminated or transition_metadata.get("terminated", False))
             truncated = bool(truncated or transition_metadata.get("truncated", False))
 
@@ -248,6 +267,16 @@ class ManipulationPrimitiveNet(gym.Env):
 
         info["transition"] = transition_info
         info["active_primitive"] = self._active_primitive
+        info["segment_done"] = bool(transition_fired and transition_info["to"] != transition_info["from"])
+        if info["segment_done"]:
+            info["segment_from"] = transition_info["from"]
+            info["segment_to"] = transition_info["to"]
+            info["segment_reason"] = transition_info["reason"] or "transition_fired"
+            if transition_additional_reward != 0.0:
+                info["segment_additional_reward"] = transition_additional_reward
+
+        if terminated or truncated:
+            self._needs_reset = True
 
         return obs, reward, terminated, truncated, info
 
@@ -276,5 +305,4 @@ class ManipulationPrimitiveNet(gym.Env):
             cameras[name].connect()
 
         return robot_dict, teleop_dict, cameras
-
 

--- a/tests/share/envs/test_manipulation_primitive_net_step.py
+++ b/tests/share/envs/test_manipulation_primitive_net_step.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 from share.envs.manipulation_primitive_net.env_manipulation_primitive_net import ManipulationPrimitiveNet
 
@@ -64,6 +65,7 @@ def _make_net(envs, transitions, active="pick", primitives=None):
     net.config = SimpleNamespace(transitions=transitions, start_primitive=active, reset_primitives=[], primitives=primitives)
     net._episode_step_count = 0
     net._last_reset_info = {}
+    net._needs_reset = False
     return net
 
 
@@ -87,6 +89,10 @@ def test_mp_net_step_executes_active_primitive():
     assert info["active_primitive"] == "pick"
     assert info["transition"]["from"] == "pick"
     assert info["transition"]["to"] == "pick"
+    assert info["primitive_done"] is False
+    assert info["primitive_terminated"] is False
+    assert info["primitive_truncated"] is False
+    assert info["segment_done"] is False
 
 
 def test_mp_net_step_switches_primitive_when_transition_fires():
@@ -106,6 +112,9 @@ def test_mp_net_step_switches_primitive_when_transition_fires():
     assert info["transition"]["from"] == "pick"
     assert info["transition"]["to"] == "place"
     assert info["transition"]["reason"] == "transition_fired"
+    assert info["segment_done"] is True
+    assert info["segment_from"] == "pick"
+    assert info["segment_to"] == "place"
 
 
 def test_mp_net_step_applies_transition_reward_and_done_flags():
@@ -126,6 +135,8 @@ def test_mp_net_step_applies_transition_reward_and_done_flags():
     assert info["transition"]["reason"] == "success"
     assert info["transition"]["transition_name"] == "success_edge"
     assert info["transition"]["transition_type"] == "threshold"
+    assert info["segment_done"] is True
+    assert info["segment_additional_reward"] == 1.75
 
 
 def test_mp_net_reset_starts_from_start_primitive():
@@ -253,3 +264,35 @@ def test_reset_primitive_routes_back_to_start_domain():
 
     assert net._active_primitive == "start"
     assert info["reset_transition_steps"] == 2
+
+
+def test_mp_net_step_marks_primitive_done_without_ending_episode():
+    pick_env = DummyEnv(obs={"obs": np.array([1.0])}, reward=0.1, terminated=True, info={"primitive_done_reason": "goal"})
+    net = _make_net(
+        envs={"pick": pick_env, "place": DummyEnv(obs={"obs": np.array([2.0])})},
+        transitions=[("pick", "place", StaticBoolTransition(False))],
+    )
+
+    _, _, terminated, truncated, info = net.step(np.array([0.0]))
+
+    assert not terminated
+    assert not truncated
+    assert info["primitive_done"] is True
+    assert info["primitive_terminated"] is True
+    assert info["primitive_truncated"] is False
+    assert info["primitive_done_reason"] == "goal"
+
+
+def test_mp_net_step_requires_reset_after_done():
+    pick_env = DummyEnv(obs={"obs": np.array([1.0])}, reward=0.5)
+    net = _make_net(
+        envs={"pick": pick_env, "place": DummyEnv(obs={"obs": np.array([2.0])})},
+        transitions=[("pick", "place", RichTransition())],
+    )
+    net._needs_reset = False
+
+    _, _, terminated, _, _ = net.step(np.array([0.0]))
+
+    assert terminated
+    with pytest.raises(RuntimeError, match="call reset"):
+        net.step(np.array([0.0]))


### PR DESCRIPTION
### Motivation
- Enforce the EPIC MPN-C runtime contract that separates primitive-segment boundaries from Gym-level episode termination and requires callers to `reset()` after an MP-Net episode ends.
- Surface primitive-level done semantics and segment boundary metadata so collectors and policies can reliably record per-primitive segments without conflating net-level termination.
- Make transition outcomes expressive enough to route primitives, apply additional reward shaping, and request net-level termination/truncation while keeping serialization work out of scope.

### Description
- Add an internal `_needs_reset` gate to `ManipulationPrimitiveNet` and clear it in `reset()` to enforce `reset()` before subsequent `step()` calls when the net ended, and add brief docstrings describing lifecycle behavior.
- Change `step()` to accept primitive env done flags (`prim_terminated`, `prim_truncated`) and surface `info` fields `primitive_done`, `primitive_terminated`, `primitive_truncated`, and `primitive_done_reason` without treating them as MP-Net episode termination by default.
- Evaluate at most one outgoing transition per `step()`, apply `additional_reward` and `terminated`/`truncated` flags from transition metadata, set `self._active_primitive` to the transition target, and emit segment boundary metadata in `info` (`segment_done`, `segment_from`, `segment_to`, `segment_reason`, optional `segment_additional_reward`).
- Mark MP-Net as requiring reset when a transition requests net-level termination/truncation or a terminal-primitive fallback applies, update config docstring wording, and update the issue board to mark MPN-301 partially done, add MPN-302 progress notes, and deprioritize serialization for now.
- Add and extend unit tests to validate primitive-level done reporting, segment info emission, transition reward propagation, and reset-before-next-step enforcement.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/share/envs/test_manipulation_primitive_net_step.py`, which passed (10 tests) and validates the `step()`/`reset()` semantics and emitted `info` fields.
- Attempted to run the wider MP-Net tests (`test_manipulation_primitive_net_config.py` and `test_manipulation_primitive_net_transitions.py`) under `PYTHONPATH=src`, but collection failed in this environment due to a missing optional runtime dependency (`atomics`), not due to the MP-Net changes.
- Local targeted test runs confirm the new semantics; full integration-level validation requires optional environment dependencies to be installed before running the entire test set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a886c7e9d48320be8256aa6c586aaf)